### PR TITLE
Added option to update only without re-insert the js script

### DIFF
--- a/slack-dark-mode.sh
+++ b/slack-dark-mode.sh
@@ -5,9 +5,11 @@
 
 OSX_SLACK_RESOURCES_DIR="/Applications/Slack.app/Contents/Resources"
 LINUX_SLACK_RESOURCES_DIR="/usr/lib/slack/resources"
+UPDATE_ONLY="false"
 
 if [[ -d $OSX_SLACK_RESOURCES_DIR ]]; then SLACK_RESOURCES_DIR=$OSX_SLACK_RESOURCES_DIR; fi
 if [[ -d $LINUX_SLACK_RESOURCES_DIR ]]; then SLACK_RESOURCES_DIR=$LINUX_SLACK_RESOURCES_DIR; fi
+if [[ "$1" == "-u" ]]; then UPDATE_ONLY="true"; fi
 
 SLACK_EVENT_LISTENER="event-listener.js"
 SLACK_FILEPATH="$SLACK_RESOURCES_DIR/app.asar.unpacked/src/static/ssb-interop.js"
@@ -15,11 +17,23 @@ THEME_FILEPATH="$SLACK_RESOURCES_DIR/dark-theme.css"
 
 #curl -sSL -o "$THEME_FILEPATH" "https://cdn.rawgit.com/laCour/slack-night-mode/master/css/raw/black.css"
 
-echo && echo "Adding Dark Theme Code to Slack... "
+if [[ "$UPDATE_ONLY" == "true" ]]; then
+  echo && echo "Updating Dark Theme Code to Slack... "
+else
+  echo && echo "Adding Dark Theme Code to Slack... "
+fi
+
 echo "This script requires sudo privileges."
 echo "You'll need to provide your password."
 sudo cp -af dark-theme.css "$THEME_FILEPATH"
-sudo tee -a "$SLACK_FILEPATH" < $SLACK_EVENT_LISTENER
+
+if [[ "$UPDATE_ONLY" == "true" ]]; then
+  echo && echo "Updating Dark Theme Code to Slack... "
+else
+  echo && echo "Adding Dark Theme Code to Slack... "
+  sudo tee -a "$SLACK_FILEPATH" < $SLACK_EVENT_LISTENER
+fi
+
 sudo sed -i -e s@SLACK_DARK_THEME_PATH@$THEME_FILEPATH@g $SLACK_FILEPATH
 
 echo && echo "Done! After executing this script, hit refresh (⌘ + R) or restart Slack for changes to take effect."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add and option `-u` to update the css file only

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
At every repository update we have to reset the Slack.app files. With this we can update without doing it

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Installed a clean Slack.app version
- Applied the dark theme
- Changed the css file
- Launched the script with `-u` option

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
