### PR TITLE
add check for sudo privileges

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Due to the changes in Slack 4.0+ this project will not be compatible with Slack 
 [![codecov](https://codecov.io/gh/LanikSJ/slack-dark-mode/branch/master/graph/badge.svg)](https://codecov.io/gh/LanikSJ/slack-dark-mode)
 ```bash
 $ git clone https://github.com/LanikSJ/slack-dark-mode
-cd slack-dark-mode && source slack-dark-mode.sh
+cd slack-dark-mode && sudo ./slack-dark-mode.sh
 ```
 or to update only:
 ```bash
 $ git clone https://github.com/LanikSJ/slack-dark-mode
-cd slack-dark-mode && ./slack-dark-mode.sh -u
+cd slack-dark-mode && sudo ./slack-dark-mode.sh -u
 ````
 ## Screenshot
 ![Screenshot](https://github.com/LanikSJ/slack-dark-mode/raw/master/images/screenshot.png "Screenshot")

--- a/slack-dark-mode.sh
+++ b/slack-dark-mode.sh
@@ -3,6 +3,12 @@
 # Homebaked Slack Dark Mode. After executing this script restart Slack for changes to take effect.
 # Adopted from https://gist.github.com/a7madgamal/c2ce04dde8520f426005e5ed28da8608
 
+if [[ $EUID -ne 0 ]]; then
+  >&2 echo "You are not root."
+  >&2 echo "This script requires sudo privileges."
+  exit 1
+fi
+
 OSX_SLACK_RESOURCES_DIR="/Applications/Slack.app/Contents/Resources"
 LINUX_SLACK_RESOURCES_DIR="/usr/lib/slack/resources"
 UPDATE_ONLY="false"


### PR DESCRIPTION
## Description

This pull request includes code additions to the `slack-dark-mode.sh` script.

## Related Issue

I have create issue #81  to accompany this pull request.  Link: https://github.com/LanikSJ/slack-dark-mode/issues/81

## Motivation and Context

This change solves the issue of a late warning to the executing user that root privileges are required, but then continues execution of the script.

## How Has This Been Tested?

I tested this code addition by simply executing the script, and seeing it abort (`exit 1`) after echoing a message to the terminal session stderr minimally instructive for re-executing the script with sudo/root privileges.

I tested this on MacOS 10.14.5, using MacOS Terminal.app with a vanilla-configuration and a GNU Bash 5.0 shell.

This change minimally effects the rest of the script, except that the script will no longer run without the executing user having sudo/root privileges.

## Screenshots (if appropriate):

## Types of changes

-   [x] New feature (non-breaking change which adds functionality)

## Checklist:

-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [] I have read the **CONTRIBUTING** document.
