### PR TITLE
Fix sed command (-i takes an arg), pre-expand ~ to fix broken edits

### DIFF
--- a/slack-dark-mode.sh
+++ b/slack-dark-mode.sh
@@ -3,8 +3,9 @@
 # Homebaked Slack Dark Mode. After executing this script restart Slack for changes to take effect.
 # Adopted from https://gist.github.com/a7madgamal/c2ce04dde8520f426005e5ed28da8608
 
-SLACK_DIRECT_LOCAL_SETTINGS="~/Library/Application\ Support/Slack/local-settings.json"
-SLACK_STORE_LOCAL_SETTINGS="~/Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Application\ Support/Slack/local-settings.json"
+MYHOME=$(ls -d ~)
+SLACK_DIRECT_LOCAL_SETTINGS="Library/Application Support/Slack/local-settings.json"
+SLACK_STORE_LOCAL_SETTINGS="Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Application\ Support/Slack/local-settings.json"
 OSX_SLACK_RESOURCES_DIR="/Applications/Slack.app/Contents/Resources"
 LINUX_SLACK_RESOURCES_DIR="/usr/lib/slack/resources"
 UPDATE_ONLY="false"
@@ -13,8 +14,8 @@ echo && echo "This script requires sudo privileges." && echo "You'll need to pro
 
 type npx
 if [[ "$?" != "0" ]]; then echo "Please install Node for your OS.  macOS users will also need to install Homebrew from https://brew.sh"; fi
-if [[ -f $SLACK_DIRECT_LOCAL_SETTINGS ]]; then sed -i 's/"bootSonic":"once"/"bootSonic":"never"/g' $SLACK_DIRECT_LOCAL_SETTINGS; fi
-if [[ -f $SLACK_STORE_LOCAL_SETTINGS ]]; then sudo sed -i 's/"bootSonic":"once"/"bootSonic":"never"/g' $SLACK_STORE_LOCAL_SETTINGS; fi
+if [[ -f "$MYHOME/$SLACK_DIRECT_LOCAL_SETTINGS" ]]; then sed -i tmp 's/"bootSonic":"once"/"bootSonic":"never"/g' "$MYHOME/$SLACK_DIRECT_LOCAL_SETTINGS"; fi
+if [[ -f "$MYHOME/$SLACK_STORE_LOCAL_SETTINGS" ]]; then sudo sed -i tmp 's/"bootSonic":"once"/"bootSonic":"never"/g' "$MYHOME/$SLACK_STORE_LOCAL_SETTINGS"; fi
 
 if [[ -d $OSX_SLACK_RESOURCES_DIR ]]; then SLACK_RESOURCES_DIR=$OSX_SLACK_RESOURCES_DIR; fi
 if [[ -d $LINUX_SLACK_RESOURCES_DIR ]]; then SLACK_RESOURCES_DIR=$LINUX_SLACK_RESOURCES_DIR; fi


### PR DESCRIPTION
Fixes issue with not finding or fixing the local-settings.json

## Description
Two primary fixes: 
1. Set a variable to expand ~ to homedir, then use that in vars instead of trying to expand elsewhere the var is used, which was not working 
1. sed -i takes an argument of the suffix to use for its temp file. added this as "tmp"

## Related Issue
https://github.com/LanikSJ/slack-dark-mode/issues/94

## Motivation and Context
fixes the script. Previously required a manual change of the localsettings file to actually work

## How Has This Been Tested?
set bootSonic back to "once"
copy/pasta top half of script (including parts I changed) up to he localsettings edit to the cli
see bootSonic set to "never" in the file.

## Screenshots (if appropriate):
    $ cat /Users/username/Library/Application\ Support/Slack/local-settings.json
    {"lastKnownLocale":"en-US","useHwAcceleration":true,"spellCheckerVersion":"V1","hasSavedStaleCookies":true,"lastElectronVersionLaunched":"4.2.1","bootSonic":"once"}
    --
    $ MYHOME=$(ls -d ~)
    $ SLACK_DIRECT_LOCAL_SETTINGS="Library/Application Support/Slack/local-settings.json"
    $ SLACK_STORE_LOCAL_SETTINGS="Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Application Support/Slack/local-settings.json"
    $ OSX_SLACK_RESOURCES_DIR="/Applications/Slack.app/Contents/Resources"
    $ LINUX_SLACK_RESOURCES_DIR="/usr/lib/slack/resources"
    $ UPDATE_ONLY="false"
    $
    $ echo && echo "This script requires sudo privileges." && echo "You'll need to provide your password."
    This script requires sudo privileges.
    You'll need to provide your password.
    $
    $ type npx
    npx is /usr/local/bin/npx
    $ if [[ "$?" != "0" ]]; then echo "Please install Node for your OS.  macOS users will also need to install Homebrew from https://brew.sh"; fi
    $ if [[ -f "$MYHOME/$SLACK_DIRECT_LOCAL_SETTINGS" ]]; then sed -i tmp 's/"bootSonic":"once"/"bootSonic":"never"/g' "$MYHOME/$SLACK_DIRECT_LOCAL_SETTINGS"; fi
    --
    $ cat /Users/username/Library/Application\ Support/Slack/local-settings.json
    {"lastKnownLocale":"en-US","useHwAcceleration":true,"spellCheckerVersion":"V1","hasSavedStaleCookies":true,"lastElectronVersionLaunched":"4.2.1","bootSonic":"never"}


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
