### PR TITLE
Remove jQuery dependency

### DIFF
--- a/event-listener.js
+++ b/event-listener.js
@@ -7,7 +7,11 @@ document.addEventListener('DOMContentLoaded', function() {
     encoding: 'utf-8'
   }, function(err, css) {
     if (!err) {
-      $("<style></style>").appendTo('head').html(css + tt__customCss);
+      const head = document.getElementsByTagName('head')[0];
+      const style = document.createElement('style');
+      style.innerHTML = css + tt__customCss;
+
+      head.appendChild(style);
     }
   });
 });


### PR DESCRIPTION
This fixes #98 by using `document.createElement` etc to modify the DOM instead of jQuery

## Related Issue
Fixes #98 

## Motivation and Context
I don't know what to say here.  The script doesn't seem to work when it expects jQuery

## How Has This Been Tested?
"It works on my machine"

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have read the **CONTRIBUTING** document.
