### PR TITLE
Feat/add windows script

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,20 @@ $ git clone https://github.com/LanikSJ/slack-dark-mode
 cd slack-dark-mode && chmod +x slack-dark-mode.sh && ./slack-dark-mode.sh -u
 ````
 
+For windows users, use the `slack-dark-mode.ps1` script:
+
+```powershell
+PS ~/> git clone https://github.com/LanikSJ/slack-dark-mode
+PS ~/> cd slack-dark-mode; .\slack-dark-mode.ps1
+```
+
+or to update only:
+
+```powershell
+PS ~/> git clone https://github.com/LanikSJ/slack-dark-mode
+PS ~/> cd slack-dark-mode; .\slack-dark-mode.ps1 -UpdateOnly
+```
+
 Screenshot
 ============
 ![Screenshot](https://github.com/LanikSJ/slack-dark-mode/raw/master/images/screenshot.png "Screenshot")

--- a/slack-dark-mode.ps1
+++ b/slack-dark-mode.ps1
@@ -1,0 +1,99 @@
+#Requires -RunAsAdministrator
+
+Param(
+    [string] $CSSUrl = "https://raw.githubusercontent.com/LanikSJ/slack-dark-mode/master/dark-theme.css",
+    [string] $SlackBase = $null,
+    [switch] $UpdateOnly
+)
+
+if (-not (Get-Command -Name "npx" -ErrorAction SilentlyContinue)) {
+    throw "npx is required to unpack slack. Please install Node for your OS."
+}
+
+$latestPath = $SlackBase
+if ([string]::IsNullOrWhiteSpace($SlackBase)) {
+    Write-Output "Locating Slack"
+    $SlackBase = Join-Path -Path $env:LOCALAPPDATA -ChildPath slack
+
+    if (-not (Test-Path -Path $SlackBase)) {
+        Write-Output "Checking for MSI-based installations"
+        $latestPath = Join-Path -Path $env:ProgramFiles -ChildPath "Slack"
+        if (-not (Test-Path -Path $latestPath)) {
+            throw "It doesn't look like slack is installed"
+        }
+
+        Write-Output "Found Slack MSI Install"
+    } else {
+        $latestPath = Get-ChildItem -Path $SlackBase -Directory -Filter "app*" | Sort-Object -Descending | Select-Object -First 1 -ExpandProperty FullName
+        Write-Output "Found Slack $($latestPath.Name) in AppData"
+    }
+} elseif (-not (Test-Path -Path $SlackBase)) {
+    throw "Could not find $SlackBase"
+}
+
+$resources = Join-Path -Path $latestPath -ChildPath "resources"
+$themeFile = Join-Path -Path $resources -ChildPath "custom_theme.css"
+
+Write-Output "Stopping Slack"
+Get-Process *slack* | Stop-Process -Force
+
+Write-Output "Updating Theme File"
+if (-not (Test-Path -Path $themeFile)) {
+    New-Item -ItemType File -Path $themeFile | Out-Null
+}
+
+Write-Output "Fetching Theme from $CSSUrl"
+Invoke-WebRequest -UseBasicParsing -Method GET -Uri $CSSUrl | Select-Object -ExpandProperty Content | Set-Content -Path $themeFile
+
+if (-not $UpdateOnly) {
+    $asar = Join-Path -Path $resources -ChildPath "app.asar"
+    $unpacked = Join-Path -Path $resources -ChildPath "app.asar.unpacked"
+
+    Write-Output "Unpacking asar archive"
+    &npx asar extract $asar $unpacked
+
+    Write-Output "Adding Hook"
+    $ssbInterop = Join-Path -Path $unpacked -ChildPath "dist" | Join-Path -ChildPath "ssb-interop.bundle.js"
+    $src = Get-Content -Raw $ssbInterop
+
+    if ($src.Contains("// BEGIN CUSTOM THEME")) {
+        Write-Output "Replacing Old Hook"
+        $src = $src.Substring(0, $src.IndexOf("// BEGIN CUSTOM THEME"))
+    }
+
+    $src.Trim() + @"
+
+
+    // BEGIN CUSTOM THEME
+    document.addEventListener('DOMContentLoaded', function() {
+        const fs = require('fs');
+        const filePath = "$($themeFile.Replace("\", "/"))";
+        const tt__customCss = '.menu ul li a:not(.inline_menu_link) {color: #fff !important;}'
+        fs.readFile(filePath, {
+          encoding: 'utf-8'
+        }, function(err, css) {
+          if (!err) {
+            `$("<style></style>").appendTo('head').html(css + tt__customCss);
+          }
+        });
+      });
+    // END CUSTOM THEME
+"@ | Set-Content -Path $ssbInterop
+
+    Write-Output "Packing asar archive"
+    &npx asar pack $unpacked $asar
+
+    Write-Output "Adding workaround to ensure theme boots"
+    $localSettingsPath = Join-Path -Path $env:APPDATA -ChildPath "Slack" | Join-Path -ChildPath "local-settings.json"
+    $localSettings = Get-Content -Raw -Path $localSettingsPath | ConvertFrom-Json
+
+    if (-not ($localSettings | Get-Member -Name "bootSonic")) {
+        $localSettings | Add-Member -MemberType NoteProperty -Name "bootSonic" -Value "never"
+    } else {
+        $localSettings.bootSonic = "never"
+    }
+
+    Set-ItemProperty -Path $localSettingsPath -Name IsReadOnly -Value $false
+    $localSettings | ConvertTo-Json -Compress | Set-Content -Path $localSettingsPath
+    Set-ItemProperty -Path $localSettingsPath -Name IsReadOnly -Value $true
+}

--- a/slack-dark-mode.ps1
+++ b/slack-dark-mode.ps1
@@ -61,23 +61,15 @@ if (-not $UpdateOnly) {
         $src = $src.Substring(0, $src.IndexOf("// BEGIN CUSTOM THEME"))
     }
 
+    $patch = Get-Content -Path (Join-Path -Path $PSScriptRoot -ChildPath "event-listener.js") -Raw
+    $patch = $patch.Replace("SLACK_DARK_THEME_PATH", $themeFile.Replace("\", "/"))
+
     $src.Trim() + @"
 
 
-    // BEGIN CUSTOM THEME
-    document.addEventListener('DOMContentLoaded', function() {
-        const fs = require('fs');
-        const filePath = "$($themeFile.Replace("\", "/"))";
-        const tt__customCss = '.menu ul li a:not(.inline_menu_link) {color: #fff !important;}'
-        fs.readFile(filePath, {
-          encoding: 'utf-8'
-        }, function(err, css) {
-          if (!err) {
-            `$("<style></style>").appendTo('head').html(css + tt__customCss);
-          }
-        });
-      });
-    // END CUSTOM THEME
+// BEGIN CUSTOM THEME
+$patch
+// END CUSTOM THEME
 "@ | Set-Content -Path $ssbInterop
 
     Write-Output "Packing asar archive"


### PR DESCRIPTION
## Description
Adds a patch script for slack on windows. The script should work for both machine-wide (MSI / Chocolatey) installs as well as per-user installs (where slack is installed in the user's AppData folder).

## Related Issue
Based off of various comments in #80 

## Motivation and Context
This makes it easy for windows users to get in on the dark-theme goodness

## How Has This Been Tested?
I've been using it for the last few weeks without issue.

## Screenshots (if appropriate):

```powershell
PS C:\Users\Nathan\slack-dark-mode> .\slack-dark-mode.ps1
Locating Slack
Checking for MSI-based installations
Found Slack MSI Install
Stopping Slack
Updating Theme File
Fetching Theme from https://raw.githubusercontent.com/LanikSJ/slack-dark-mode/master/dark-theme.css
Unpacking asar archive
npx: installed 21 in 2.463s
Adding Hook
Replacing Old Hook
Packing asar archive
npx: installed 21 in 2.269s
Adding workaround to ensure theme boots
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] My code follows the code style of this project. (No prior art for powershell scripts in this repo, I'm open to suggestions here)
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] ~~I have read the **CONTRIBUTING** document.~~ (Couldn't find a `CONTRIBUTING` doc)
