### PR TITLE
Introduce CSS properties for easier color adjustment

### DIFF
--- a/dark-theme.css
+++ b/dark-theme.css
@@ -1449,6 +1449,10 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
   color: var(--main-text);
 }
 
+.c-texty_autocomplete {
+  background-color: var(--main-dark-highlight);
+}
+
 .c-texty_input .ql-placeholder {
   color: var(--main-text);
 }

--- a/dark-theme.css
+++ b/dark-theme.css
@@ -1,63 +1,72 @@
+:root {
+  --main-bg-color: #222; /* General background */
+  --main-dark-highlight: #363636; /* Text input, dividers */
+  --main-highlight: #545454; /* Message bar top (new messages), Currently selected chat, Nes messages line */
+  --main-text: #e6e6e6; /* Main text in the chat windows */
+  --text-hover: #c7c7c7; /* Based on the usage should be link hover color */
+}
+
+
 .p-unreads_view__header{
- background: #545454 !important;
- color: #222 !important;
+ background: var(--main-highlight) !important;
+ color: var(--main-bg-color) !important;
 }
 
 ::-moz-placeholder {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
   filter: none;
   opacity: 0.5;
 }
 
 ::-webkit-input-placeholder {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
   -webkit-filter: none;
   filter: none;
   opacity: 0.5;
 }
 
 ::-webkit-scrollbar-corner {
-  background: #222 !important;
+  background: var(--main-bg-color) !important;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #545454 !important;
-  border-left-color: #363636 !important;
-  border-right-color: #363636 !important;
-  color: #222 !important;
+  background: var(--main-highlight) !important;
+  border-left-color: var(--main-dark-highlight) !important;
+  border-right-color: var(--main-dark-highlight) !important;
+  color: var(--main-bg-color) !important;
 }
 
 ::-webkit-scrollbar-track {
-  background: #363636 !important;
-  border-left-color: #363636 !important;
-  border-right-color: #363636 !important;
-  color: #363636 !important;
+  background: var(--main-dark-highlight) !important;
+  border-left-color: var(--main-dark-highlight) !important;
+  border-right-color: var(--main-dark-highlight) !important;
+  color: var(--main-dark-highlight) !important;
 }
 
 ::placeholder {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
   filter: none;
   opacity: 0.5;
 }
 
 .accordion_section {
-  border-bottom-color: #222;
+  border-bottom-color: var(--main-bg-color);
 }
 
 a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .accordion_section h4 {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .accordion_section h4 a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .accordion_section_fixed {
-  border-bottom-color: #222 !important;
+  border-bottom-color: var(--main-bg-color) !important;
 }
 
 .action_cog {
@@ -69,7 +78,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .active .tab_container .file_list_item {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .admin_invite_row .delete_row, .admin_invite_row .hide_custom_message, .admin_invites_custom_message_container .delete_row, .admin_invites_custom_message_container .hide_custom_message {
@@ -89,15 +98,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .admin_invites_account_type_option {
-  border-bottom: 1px solid #363636;
+  border-bottom: 1px solid var(--main-dark-highlight);
 }
 
 .admin_invites_account_type_option p {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .admin_invites_account_type_option:hover:not(.disabled) h3 {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .admin_invites_account_type_option.disabled .account_type_disabled_hover {
@@ -109,7 +118,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .admin_list_item .admin_member_full_name, .admin_list_item .admin_member_real_name {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .admin_list_item .admin_member_type, .admin_list_item .admin_member_caret {
@@ -129,26 +138,26 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .admin_list_item {
-  border-bottom-color: #222;
+  border-bottom-color: var(--main-bg-color);
   color: #949494;
 }
 
 .admin_list_item:hover {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .admin_list_item.error, .admin_list_item.expanded, .admin_list_item.processing, .admin_list_item.success {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .admin_list_item.expanded .btn_outline {
-  border-color: #222;
-  color: #e6e6e6 !important;
+  border-color: var(--main-bg-color);
+  color: var(--main-text) !important;
 }
 
 .admin_list_item.expanded .btn_outline:hover {
-  border-color: #363636;
-  color: #e6e6e6 !important;
+  border-color: var(--main-dark-highlight);
+  color: var(--main-text) !important;
 }
 
 .admin_list_item.expanded .sub_action {
@@ -156,7 +165,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .admin_list_item.expanded .sub_action:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .admin_list_item.invite_item.bouncing .email {
@@ -172,7 +181,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .admin_pref:not(:first-of-type) {
-  border-top-color: #222;
+  border-top-color: var(--main-bg-color);
 }
 
 .admin_pref.locked {
@@ -180,23 +189,23 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .alert h4, .c-alert h4, .c-alert--boxed h4 {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .alert-info {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   border-color: #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .alert-info h4 {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .alert, .c-alert, .c-alert--boxed {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   border-color: #000;
-  color: #e6e6e6;
+  color: var(--main-text);
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5);
 }
 
@@ -205,7 +214,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .api_articles .api_articles_section {
-  border-bottom-color: #222;
+  border-bottom-color: var(--main-bg-color);
 }
 
 .api_articles .article_tag_count {
@@ -217,7 +226,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .api.feature_related_content #api_related_content h2 {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .app_preview_link_slug, .internal_member_link, .internal_user_group_link {
@@ -225,8 +234,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .app_card, .large_app_card {
-  background-color: #222;
-  border: 1px solid #363636;
+  background-color: var(--main-bg-color);
+  border: 1px solid var(--main-dark-highlight);
 }
 
 .application_config aside {
@@ -250,7 +259,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .attachment_group .attachment_title a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .attachment_group .delete_attachment_link ts-icon::before {
@@ -258,7 +267,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .attachment_group .delete_attachment_link:hover ts-icon::before {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .attachment_group .inline_attachment.message_unfurl .attachment_source .attachment_source_name a, .attachment_group .inline_attachment.message_unfurl .attachment_source .attachment_source_name span {
@@ -270,7 +279,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .attachment_group .inline_attachment.reply_broadcast+.attachment_rule::after {
-  border-bottom: 1px solid #363636;
+  border-bottom: 1px solid var(--main-dark-highlight);
 }
 
 .attachment_group .media_caret {
@@ -278,18 +287,18 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .attachment_group.has_container .inline_attachment::after {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .attachment_group.has_container {
-  background: #222;
-  border: 1px solid #363636;
+  background: var(--main-bg-color);
+  border: 1px solid var(--main-dark-highlight);
 }
 
 .attachment_group.has_container.has_link:hover {
-  border-bottom-color: #363636;
-  border-left-color: #363636;
-  border-right-color: #363636;
+  border-bottom-color: var(--main-dark-highlight);
+  border-left-color: var(--main-dark-highlight);
+  border-right-color: var(--main-dark-highlight);
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15);
 }
 
@@ -298,13 +307,13 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .author_cell {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .backup_codes {
   background: #000;
-  border-color: #545454;
-  color: #e6e6e6;
+  border-color: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .basic_share_dialog .share_dialog_divider {
@@ -312,20 +321,20 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .billing_contact {
-  border-bottom: 1px solid #222;
+  border-bottom: 1px solid var(--main-bg-color);
 }
 
 .billing_invoice tbody tbody tr {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .billing_selection .billing_selection__price {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .billing_selection {
   border-color: #000;
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
 }
 
@@ -334,12 +343,12 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .billing_selection.active {
-  background: #545454;
+  background: var(--main-highlight);
   border-color: #828282;
 }
 
 .billing_selection.billing_selection--refactor {
-  border-color: #545454;
+  border-color: var(--main-highlight);
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
 }
 
@@ -348,16 +357,16 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .billing_selection.billing_selection--refactor.active {
-  background: #545454;
+  background: var(--main-highlight);
   border-color: #828282;
 }
 
 .billing_settings_label_name {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .bordered {
-  border: 1px solid #363636;
+  border: 1px solid var(--main-dark-highlight);
 }
 
 .bot_label {
@@ -366,33 +375,33 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .bot_message .message_sender {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .bot_message .message_sender a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .bottom_border {
-  border-bottom: 1px solid #363636;
+  border-bottom: 1px solid var(--main-dark-highlight);
 }
 
 .bottom_mark_all_read {
-  border-top-color: #363636;
+  border-top-color: var(--main-dark-highlight);
 }
 
 .btn {
-  background-color: #545454;
-  color: #e6e6e6 !important;
+  background-color: var(--main-highlight);
+  color: var(--main-text) !important;
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15);
 }
 
 .btn_basic:focus, .btn_basic:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .btn_info, .btn.btn_success {
-  background-color: #222 !important;
+  background-color: var(--main-bg-color) !important;
 }
 
 .btn_link {
@@ -400,11 +409,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .btn_link:hover, .btn_link:focus {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .btn_outline {
-  background: #222;
+  background: var(--main-bg-color);
   color: #949494 !important;
 }
 
@@ -413,11 +422,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .btn_outline:active {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .btn_outline.active {
-  color: #c7c7c7 !important;
+  color: var(--text-hover) !important;
 }
 
 .btn_outline.btn_transparent {
@@ -434,12 +443,12 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .btn_outline.btn_transparent.active, .btn_outline.btn_transparent.hover, .btn_outline.btn_transparent:active, .btn_outline.btn_transparent:focus, .btn_outline.btn_transparent:hover {
   background-color: rgba(84, 84, 84, 0.9) !important;
-  color: #c7c7c7 !important;
+  color: var(--text-hover) !important;
 }
 
 .btn_outline.hover, .btn_outline:focus, .btn_outline:hover {
-  background: #222;
-  color: #c7c7c7 !important;
+  background: var(--main-bg-color);
+  color: var(--text-hover) !important;
 }
 
 .btn_warning, .btn_danger {
@@ -447,8 +456,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .btn-danger .caret, .btn-info .caret, .btn-inverse .caret, .btn-primary .caret, .btn-success .caret, .btn-warning .caret {
-  border-bottom-color: #e6e6e6;
-  border-top-color: #e6e6e6;
+  border-bottom-color: var(--main-text);
+  border-top-color: var(--main-text);
 }
 
 .btn-group>.btn+.dropdown-toggle {
@@ -460,15 +469,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .btn-group.open .btn.dropdown-toggle {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 .btn.btn_attachment {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .btn.btn_attachment:hover, .btn.btn_attachment:focus {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   border-color: #828282;
 }
 
@@ -494,11 +503,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .btn.btn_outline.btn_danger, .btn.btn_outline.btn_warning {
   background-color: #bf360c !important;
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .btn.btn_outline.btn_danger:focus, .btn.btn_outline.btn_danger:hover, .btn.btn_outline.btn_warning:focus, .btn.btn_outline.btn_warning:hover {
-  background-color: #222 !important;
+  background-color: var(--main-bg-color) !important;
   border-color: #bf360c !important;
   color: #bf360c !important;
 }
@@ -522,8 +531,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .btn.hover, .btn:focus, .btn:hover, .btn.active, .btn:active {
-  background-color: #545454;
-  color: #e6e6e6;
+  background-color: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .bullet {
@@ -531,7 +540,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-app_badge {
-  background: #545454;
+  background: var(--main-highlight);
   box-shadow: 0 0 2px rgba(#000, 0.25);
   color: #949494;
 }
@@ -541,7 +550,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-archive_footer__title {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .c-button-unstyled {
@@ -549,11 +558,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-calendar_month__day_of_week_heading {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-calendar_view_header__stepper_btn, .c-calendar_view_header__title_btn {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-calendar_view_header__stepper_btn:disabled, .c-calendar_view_header__title_btn:disabled {
@@ -561,7 +570,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-calendar_view_header__stepper_btn:hover, .c-calendar_view_header__title_btn:hover {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 .c-channel_name, .c-channel_name__text, .c-channel_name__text--inline {
@@ -569,19 +578,19 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-date_picker__dropdown {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .c-date_picker_calendar__date--disabled, .c-date_picker_calendar__date--disabled:hover {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .c-fullscreen_modal__close--with_header .c-deprecated-icon {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .c-dialog .p-custom_status_input__duration_picker_select .c-input_select__selected_value--placeholder {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-dialog .p-custom_status_input__duration_picker_select {
@@ -590,35 +599,35 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .c-dialog__body .p-file_upload_dialog__preview, .c-dialog__body .p-file_upload_dialog__preview_image {
   background-color: #000;
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 .c-dialog__body .p-share_dialog_message_input {
   background-color: #000;
-  border-color: #363636;
-  color: #e6e6e6;
+  border-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .c-dialog__body .p-share_dialog_message_input.focus {
-  border-color: #545454;
+  border-color: var(--main-highlight);
   box-shadow: unset;
 }
 
 .c-dialog__body {
-  background: #222222;
+  background: var(--main-bg-color);
 }
 
 .c-dialog__body input.c-input_text .c-input_character_count {
-  background-color: #363636;
-  color: #e6e6e6;
+  background-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .c-dialog__body input.c-input_text {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 .c-dialog__body input.c-input_text:focus {
-  border-color: #545454;
+  border-color: var(--main-highlight);
   box-shadow: unset;
 }
 
@@ -627,16 +636,16 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-dialog__footer .c-button {
-  background-color: #545454;
-  color: #e6e6e6;
+  background-color: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .c-dialog__footer .p-file_upload_dialog__footer_share_inputs {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-dialog__footer {
-  background: #222222;
+  background: var(--main-bg-color);
 }
 
 .c-dialog__header .c-dialog__close:hover {
@@ -644,7 +653,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-dialog__header .c-dialog__title, .c-dialog__header .c-dialog__close {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-dialog__header {
@@ -652,35 +661,35 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-dialog__header, .c-dialog__body, .c-dialog__footer {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 .c-dialog_speed_bump {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 .c-dialog__title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-enhanced_text_input {
-  background-color: #545454;
-  border-color: #363636;
+  background-color: var(--main-highlight);
+  border-color: var(--main-dark-highlight);
   color: #949494;
 }
 
 .c-enhanced_text_input:hover, .c-enhanced_text_input.c-enhanced_text_input--active {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .c-file__action_button, .c-file__action_button:link, .c-file__action_button:focus, .c-file__action_button:hover {
-  background: #545454;
-  border-color: #363636;
+  background: var(--main-highlight);
+  border-color: var(--main-dark-highlight);
   color: #fff;
 }
 
 .c-file__meta {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-file__slide--meta {
@@ -692,16 +701,16 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-filter_input {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 .c-fullscreen_modal__body {
-  color: #e6e6e6;
-  background-color: #222;
+  color: var(--main-text);
+  background-color: var(--main-bg-color);
 }
 
 .c-fullscreen_modal__header {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .c-hint {
@@ -717,26 +726,26 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-input_select {
-  background: #545454;
-  border-color: #363636;
-  color: #e6e6e6;
+  background: var(--main-highlight);
+  border-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .c-input_select_options_list__option {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-input_select_options_list_container:not(.c-input_select_options_list_container--always-open) {
-  background: #545454;
-  border-color: #363636;
-  color: #e6e6e6;
+  background: var(--main-highlight);
+  border-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .c-keyboard_key {
-  background: #545454;
+  background: var(--main-highlight);
   border-color: #828282;
   box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25);
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-label__subtext {
@@ -744,7 +753,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-label__text {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-link--button {
@@ -756,34 +765,34 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-member .external_team_badge {
-  background-color: #545454;
-  box-shadow: 0 0 0 2px #545454;
+  background-color: var(--main-highlight);
+  box-shadow: 0 0 0 2px var(--main-highlight);
 }
 
 .c-member .external_team_badge::after {
-  box-shadow: inset 0 0 0 1px #545454;
+  box-shadow: inset 0 0 0 1px var(--main-highlight);
 }
 
 .c-member .external_team_badge.default {
   background-color: #949494;
-  color: #e6e6e6;
+  color: var(--main-text);
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15);
 }
 
 .c-member__current-status--small::before, .c-member__secondary-name--large+.c-member__current-status--large::before, .c-member__secondary-name--medium+.c-member__current-status--medium::before {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-member__display-name--large, .c-member__title--large {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-member__display-name, .c-team__display-name, .c-usergroup__handle {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-member__name--small, .c-team__name--small, .c-usergroup__name--small {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-member__other-names--large {
@@ -791,7 +800,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-member__secondary-name--medium {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-member--dark .c-member__current-status {
@@ -803,7 +812,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-member--dark .c-member__display-name, .c-member--dark .presence {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-member--dark .c-member__name, .c-member--dark .c-member__secondary-name {
@@ -828,16 +837,16 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .c-member--small .team_image.default {
   background-color: #949494;
-  color: #e6e6e6;
+  color: var(--main-text);
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15);
 }
 
 .c-member--small .team_image.icon_16 {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 .c-menu {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .c-menu_item__description {
@@ -857,21 +866,21 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message .c-button--outline {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   color: #949494;
 }
 
 .c-message .c-button--outline:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .c-message .c-button--primary {
-  background-color: #545454;
-  color: #e6e6e6;
+  background-color: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .c-message__body {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message__body--automated {
@@ -896,16 +905,16 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message__call_attachment {
-  background: #222;
+  background: var(--main-bg-color);
   border-color: rgba(84, 84, 84, 0.1);
 }
 
 .c-message__call_icon {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message__call_info {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message__call_name+.c-message__call_description::before {
@@ -913,7 +922,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message__call_name--linked {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message__call_sub {
@@ -937,13 +946,13 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message__editor__input, .c-message__editor__input--legacy {
-  background: #545454;
-  border-color: #363636;
-  color: #e6e6e6;
+  background: var(--main-highlight);
+  border-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .c-message__editor__input.focus, .c-message__editor__input--legacy.focus {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
   box-shadow: 0 0 7px rgba(0, 0, 0, 0.15);
 }
 
@@ -968,7 +977,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message__label__highlight_positive--active, .c-message__label__highlight_negative--active {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message__label__highlight_positive, .c-message__label__highlight_negative {
@@ -976,7 +985,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message__label__highlight_title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message__reply_bar_description {
@@ -988,11 +997,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message__reply_bar:hover .c-message__reply_bar_view_thread, .c-message__reply_bar--focus .c-message__reply_bar_view_thread {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 .c-message__reply_bar:hover, .c-message__reply_bar--focus {
-  background-color: #222;
+  background-color: var(--main-bg-color);
   border-color: #000;
 }
 
@@ -1005,7 +1014,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message__resend, .c-message__cancel {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message__sender .c-emoji__text_mode_icon {
@@ -1013,11 +1022,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message__sender {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message__sender a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message__tombstone_icon {
@@ -1026,30 +1035,30 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message_actions__button {
-  border-right-color: #363636;
+  border-right-color: var(--main-dark-highlight);
   color: #949494;
 }
 
 .c-message_actions__button:active {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 .c-message_actions__button:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message_actions__container {
-  background: #222;
-  border-color: #363636;
+  background: var(--main-bg-color);
+  border-color: var(--main-dark-highlight);
 }
 
 .c-message_actions__container:hover {
-  border-color: #545454;
+  border-color: var(--main-highlight);
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25);
 }
 
 .c-message_attachment {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message_attachment__author {
@@ -1069,7 +1078,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message_attachment__border {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 .c-message_attachment__delete {
@@ -1077,7 +1086,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message_attachment__delete:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .c-message_attachment__footer {
@@ -1097,11 +1106,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message_attachment__part+.c-message_attachment__part::before {
-  color: #545454;
+  color: var(--main-highlight);
 }
 
 .c-message_attachment__pretext {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message_attachment__select {
@@ -1109,7 +1118,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message_attachment__select:hover, .c-message_attachment__select:active {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .c-message_attachment__text_expander {
@@ -1117,7 +1126,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message_attachment__title_link span {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message_attachment__video_buttons {
@@ -1129,30 +1138,30 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message_attachment__video_link:visited, .c-message_attachment__video_link:link {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message_attachment__video_play, .c-message_attachment__video_link {
-  color: #e6e6e6;
+  color: var(--main-text);
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
 }
 
 .c-message_attachment__video_play:hover, .c-message_attachment__video_link:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message_group {
-  background-color: #222;
-  border-color: #363636;
+  background-color: var(--main-bg-color);
+  border-color: var(--main-dark-highlight);
 }
 
 .c-message_group__divider_text {
-  background-color: #222;
-  color: #e6e6e6;
+  background-color: var(--main-bg-color);
+  color: var(--main-text);
 }
 
 .c-message_group__header {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message_group:hover .c-message_group__header {
@@ -1160,7 +1169,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message_kit__gutter__left, .c-message_kit__gutter__right, .c-message_kit__background {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .c-message_kit__background, .c-message_kit__message, .c-message_kit__thread_message {
@@ -1171,7 +1180,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message_kit__file__meta {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message_list .c-scrollbar__bar {
@@ -1183,12 +1192,12 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message_list__day_divider__label__pill {
-  background: #222;
+  background: var(--main-bg-color);
   position: relative;
 }
 
 .c-message_list__day_divider__line {
-  border-top-color: #363636;
+  border-top-color: var(--main-dark-highlight);
 }
 
 .c-message_list__spinner {
@@ -1196,17 +1205,17 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message_list__unread_divider__label {
-  background: #222;
+  background: var(--main-bg-color);
   box-shadow: 0 0 2px rgba(0, 0, 0, 0.25);
-  color: #545454;
+  color: var(--main-highlight);
 }
 
 .c-message_list__unread_divider__separator {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .c-message--custom_response .c-message__label__icon, .c-message--sli_highlight .c-message__label__icon {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message--custom_response {
@@ -1218,7 +1227,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message--dense .c-message__content_header .c-custom_status {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 .c-message--dense .c-timestamp__label {
@@ -1226,9 +1235,9 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message--editing {
-  background: #363636;
-  border-color: #363636;
-  color: #e6e6e6;
+  background: var(--main-dark-highlight);
+  border-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .c-message--focus:not(.c-message--highlight):not(.c-message--standalone):not(.c-message--pinned):not(.c-message--ephemeral):not(.c-message--custom_response):not(.c-message--starred):not(.c-message--sli_highlight) {
@@ -1240,7 +1249,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message--light .c-message__sender .c-message__sender_link {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-message--pinned .c-message__label__icon {
@@ -1292,7 +1301,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-mini_calendar__month_button:disabled, .c-mini_calendar__month_button:disabled:hover {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .c-mrkdwn__broadcast--mention, .c-mrkdwn__broadcast--mention:hover, .c-mrkdwn__highlight,
@@ -1314,17 +1323,17 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-oauth_scope_info__dangerous_scope:not(:first-child), .c-oauth_scope_info__safe_scope {
-  border-top-color: #545454;
+  border-top-color: var(--main-highlight);
 }
 
 .c-oauth_scope_info__dangerous_scopes {
   border-left-color: #bf360c;
-  border-right-color: #545454;
-  border-top-color: #545454;
+  border-right-color: var(--main-highlight);
+  border-top-color: var(--main-highlight);
 }
 
 .c-oauth_scope_info__dangerous_scopes, .c-oauth_scope_info__safe_scopes {
-  border-bottom-color: #545454;
+  border-bottom-color: var(--main-highlight);
 }
 
 .c-oauth_scope_info__spacer_icon {
@@ -1332,7 +1341,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-pillow_file__description, .c-pillow_file__title, .c-pillow_file__snippet__truncated {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-pillow_file__content--collapsed::after {
@@ -1340,7 +1349,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-pillow_file__post__content code, .c-pillow_file__post__content pre {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .c-pillow_file_container .c-pillow_file__swap .c-pillow_file__slide {
@@ -1352,8 +1361,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-scrollbar--monkey .c-scrollbar__bar {
-  background: #545454;
-  box-shadow: 0 3px 0 #222, 0 -3px 0 #222;
+  background: var(--main-highlight);
+  box-shadow: 0 3px 0 var(--main-bg-color), 0 -3px 0 var(--main-bg-color);
 }
 
 .c-scrollbar--monkey .c-scrollbar__track {
@@ -1369,22 +1378,22 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-search__input_box__clear, .c-search__input_box__icon, .c-search__section_header, .c-search__input_and_close__close {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-search_autocomplete footer {
-  background: #363636;
-  border-color: #545454;
-  color: #e6e6e6;
+  background: var(--main-dark-highlight);
+  border-color: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .c-search_autocomplete__suggestion_item .token {
-  background-color: #222222;
-  color: #e6e6e6;
+  background-color: var(--main-bg-color);
+  color: var(--main-text);
 }
 
 .c-search_autocomplete__suggestion_item {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-search_autocomplete__suggestion_item--selected {
@@ -1392,28 +1401,28 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-search_message__body {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-search_modal .popover>div, .c-search_modal .c-search__input_box,
 .c-search_modal:not(.c-search_modal--primarysearch) .popover>div, .c-search_modal:not(.c-search_modal--primarysearch) .c-search__input_box {
-  background: #363636;
-  border-color: #545454;
-  color: #e6e6e6;
+  background: var(--main-dark-highlight);
+  border-color: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .c-snippet .c-file_container {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .c-snippet .c-file_container.c-file_container--gradient::after {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0), #222);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0), var(--main-bg-color));
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;
 }
 
 .c-select_button__content {
-  color: #363636;
+  color: var(--main-dark-highlight);
 }
 
 .c-tabs__tab {
@@ -1422,25 +1431,25 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .c-tabs__tab_menu {
   background-color: transparent;
-  box-shadow: inset 0 -2px 0 0 #545454;
+  box-shadow: inset 0 -2px 0 0 var(--main-highlight);
 }
 
 .c-tabs__tab_menu--plastic {
   background-color: transparent;
-  box-shadow: inset 0 -2px 0 0 #545454;
+  box-shadow: inset 0 -2px 0 0 var(--main-highlight);
 }
 
 .c-tabs__tab:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-tabs__tab.c-tabs__tab--active, .c-tabs__tab:active, .c-tabs__tab:focus {
   box-shadow: inset 0 -2px 0 0 #828282;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-texty_input .ql-placeholder {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-texty_input.focus .c-texty_input__button {
@@ -1452,28 +1461,28 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-tooltip__tip {
-  background-color: #545454;
-  color: #e6e6e6;
+  background-color: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .c-tooltip__tip--bottom .c-tooltip__tip__arrow {
-  border-bottom-color: #545454;
+  border-bottom-color: var(--main-highlight);
 }
 
 .c-tooltip__tip--bottom-left .c-tooltip__tip__arrow {
-  border-bottom-color: #545454;
+  border-bottom-color: var(--main-highlight);
 }
 
 .c-tooltip__tip--bottom-right .c-tooltip__tip__arrow {
-  border-bottom-color: #545454;
+  border-bottom-color: var(--main-highlight);
 }
 
 .c-tooltip__tip--left .c-tooltip__tip__arrow {
-  border-left-color: #545454;
+  border-left-color: var(--main-highlight);
 }
 
 .c-tooltip__tip--right .c-tooltip__tip__arrow {
-  border-right-color: #545454;
+  border-right-color: var(--main-highlight);
 }
 
 .c-tooltip__tip--success {
@@ -1499,20 +1508,20 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-tooltip__tip--top .c-tooltip__tip__arrow {
-  border-top-color: #545454;
+  border-top-color: var(--main-highlight);
 }
 
 .c-tooltip__tip--top-left .c-tooltip__tip__arrow {
-  border-top-color: #545454;
+  border-top-color: var(--main-highlight);
 }
 
 .c-tooltip__tip--top-right .c-tooltip__tip__arrow {
-  border-top-color: #545454;
+  border-top-color: var(--main-highlight);
 }
 
 .c-unified_member__display-name, .c-unified_member__secondary-name, .c-unified_member__title,
 .c-unified_member__other-names, .c-unified_member__other-names {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .c-usergroup__not-in-channel-context--small {
@@ -1521,11 +1530,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .c-usergroup--small .c-usergroup__icon {
   background-color: #949494;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .c-virtual_list__item {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .c-virtual_list__item--focus:focus .c-message_list__focus_indicator {
@@ -1533,7 +1542,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-virtual_list.c-virtual_list--scrollbar.c-scrollbar.c-scrollbar--hidden>div.c-scrollbar__hider {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .c3 line, .c3 path {
@@ -1545,19 +1554,19 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c3-chart-arc path {
-  stroke: #363636;
+  stroke: var(--main-dark-highlight);
 }
 
 .c3-chart-arc text {
-  fill: #363636;
+  fill: var(--main-dark-highlight);
 }
 
 .c3-chart-arcs .c3-chart-arcs-background {
-  fill: #545454;
+  fill: var(--main-highlight);
 }
 
 .c3-chart-arcs .c3-chart-arcs-gauge-max, .c3-chart-arcs .c3-chart-arcs-gauge-min {
-  fill: #363636;
+  fill: var(--main-dark-highlight);
 }
 
 .c3-chart-arcs .c3-chart-arcs-gauge-unit {
@@ -1565,7 +1574,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c3-circle._expanded_ {
-  stroke: #363636;
+  stroke: var(--main-dark-highlight);
 }
 
 .c3-grid line {
@@ -1573,39 +1582,39 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c3-grid text {
-  fill: #e6e6e6;
+  fill: var(--main-text);
 }
 
 .c3-legend-background {
-  fill: #363636;
-  stroke: #545454;
+  fill: var(--main-dark-highlight);
+  stroke: var(--main-highlight);
 }
 
 .c3-region {
-  fill: #545454;
+  fill: var(--main-highlight);
 }
 
 .c3-selected-circle {
-  fill: #363636;
+  fill: var(--main-dark-highlight);
 }
 
 .c3-tooltip {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   box-shadow: 7px 7px 12px -9px rgba(0, 0, 0, 0.5);
 }
 
 .c3-tooltip td {
-  background-color: #363636;
-  border-left-color: #545454;
+  background-color: var(--main-dark-highlight);
+  border-left-color: var(--main-highlight);
 }
 
 .c3-tooltip th {
-  background-color: #363636;
-  color: #e6e6e6;
+  background-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .c3-tooltip tr {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .candy_red_bg {
@@ -1613,21 +1622,21 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .card h3 a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .card, .tab_pane {
-  background: #363636;
+  background: var(--main-dark-highlight);
   border: 1px solid #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .channel_actions_toggle.active:focus, .details_toggle.active:focus {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .channel_archive_messages.card .col:first-child {
-  border-right: 1px solid #545454;
+  border-right: 1px solid var(--main-highlight);
 }
 
 .channel_calls_button .call_icon.call_window_offline {
@@ -1635,16 +1644,16 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .channel_header .blue_on_hover:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .channel_header {
-  background: #222;
-  box-shadow: inset 1px 0 0 0 #222;
+  background: var(--main-bg-color);
+  box-shadow: inset 1px 0 0 0 var(--main-bg-color);
 }
 
 .channel_header_icon {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .channel_header_info button {
@@ -1656,17 +1665,17 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .channel_invite_member .add_icon, .channel_invite_member_small .add_icon, .channel_invite_pending_user_small .add_icon {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .channel_invite_member .invite_user_group_avatar, .channel_invite_member_small .invite_user_group_avatar {
   background-color: #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .channel_invite_member .invite_user_group_avatar, .channel_invite_member_small .invite_user_group_avatar, .channel_invite_pending_user_small .invite_user_group_avatar {
-  background-color: #222;
-  color: #e6e6e6;
+  background-color: var(--main-bg-color);
+  color: var(--main-text);
 }
 
 .channel_invite_member .name_container .not_in_token, .channel_invite_member_small .name_container .not_in_token {
@@ -1674,24 +1683,24 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .channel_modal_header {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .channel_overlay {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
   color: #949494;
 }
 
 .channel_overlay_title_shared {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .channel_overlay_title_wrap {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 .channel_overlay.channel_overlay_redesign .channel_overlay_title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .channel_overlay.channel_overlay_redesign li {
@@ -1699,7 +1708,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .channel_page_member_row {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .channel_page_member_row a {
@@ -1707,12 +1716,12 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .channel_page_member_row:hover {
-  background-color: #545454;
-  border-color: #363636;
+  background-color: var(--main-highlight);
+  border-color: var(--main-dark-highlight);
 }
 
 .channel_page_member_row.away {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .channel_page_member_row.away a {
@@ -1720,11 +1729,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .channel_prefs__muting_checkbox_label {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .channel_prefs__muting_checkbox_label:not(.subtle_silver) {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .channel_prefs_body__mute_help_text {
@@ -1732,28 +1741,28 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .channel_prefs_body__section_header_icon::before {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .channel_prefs_body__section_header_title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .channel_prefs_modal_header {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .channel_prefs_notifications_table {
-  border-bottom-color: #363636;
-  color: #e6e6e6;
+  border-bottom-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .channel_prefs_notifications_table__large_cell, .channel_prefs_notifications_table__small_cell, .channel_prefs_notifications_table__row_title {
-  border-bottom-color: #545454 !important;
+  border-bottom-color: var(--main-highlight) !important;
 }
 
 .channel_title .channel_name_container .channel_name {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .channel_title .channel_name_container .channel_name.muted {
@@ -1778,41 +1787,41 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .channels_list_holder .unread_highlights {
   background: #bf360c;
-  color: #e6e6e6;
+  color: var(--main-text);
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
 }
 
 .channels_list_holder .unread_msgs {
-  background: #222;
-  color: #e6e6e6;
+  background: var(--main-bg-color);
+  color: var(--main-text);
 }
 
 .channels_list_holder h2 {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .channels_list_holder h2.hoverable:not(.jquery_hover):hover {
-  color: #e6e6e6;
+  color: var(--main-text);
   opacity: 0.8;
 }
 
 .channels_list_holder ul {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .channels_list_holder ul li .channel_name, .channels_list_holder ul li .group_name, .channels_list_holder ul li .im_name, .channels_list_holder ul li .mpim_name, .channels_list_holder ul li>a {
-  background: #363636;
+  background: var(--main-dark-highlight);
   color: rgba(230, 230, 230, 0.8) !important;
 }
 
 .channels_list_holder ul li .channel_name:hover, .channels_list_holder ul li .group_name:hover, .channels_list_holder ul li .im_name:hover, .channels_list_holder ul li .mpim_name:hover, .channels_list_holder ul li>a:hover {
-  background: #222 !important;
+  background: var(--main-bg-color) !important;
   border-bottom-right-radius: 0.25rem;
   border-top-right-radius: 0.25rem;
 }
 
 .channels_list_holder ul li .primary_action.im_name:hover .im_name_background, .channels_list_holder ul li .primary_action.feature_user_custom_status:hover .im_name_background, .channels_list_holder ul li .primary_action:not(.feature_user_custom_status):hover {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .channels_list_holder ul li {
@@ -1820,11 +1829,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .channels_list_holder ul li.mention a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .channels_list_holder ul li.unread .prefix {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
   opacity: 1;
 }
 
@@ -1841,8 +1850,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .client_channels_list_container {
-  background-color: #363636;
-  border-right-color: #222;
+  background-color: var(--main-dark-highlight);
+  border-right-color: var(--main-bg-color);
 }
 
 .client_header_icon {
@@ -1852,7 +1861,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .close {
-  color: #e6e6e6;
+  color: var(--main-text);
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5);
 }
 
@@ -1861,7 +1870,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .close_flexpane:focus, .close_flexpane:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .cm-invalidchar, .cm-s-default .cm-error {
@@ -1905,7 +1914,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .cm-s-default .cm-hr {
-  color: #363636;
+  color: var(--main-dark-highlight);
 }
 
 .cm-s-default .cm-keyword {
@@ -1957,18 +1966,18 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .CodeMirror .CodeMirror-gutters {
-  background-color: #363636;
-  border-right: 1px solid #222;
+  background-color: var(--main-dark-highlight);
+  border-right: 1px solid var(--main-bg-color);
 }
 
 .CodeMirror {
   background: #000;
-  border: 1px solid #363636;
-  color: #e6e6e6 !important;
+  border: 1px solid var(--main-dark-highlight);
+  color: var(--main-text) !important;
 }
 
 .CodeMirror div.CodeMirror-cursor {
-  border-left: 1px solid #e6e6e6;
+  border-left: 1px solid var(--main-text);
 }
 
 .CodeMirror pre {
@@ -1984,7 +1993,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .CodeMirror-gutter-filler, .CodeMirror-scrollbar-filler {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .CodeMirror-guttermarker {
@@ -2012,7 +2021,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .CodeMirror.cm-fat-cursor div.CodeMirror-cursor {
-  background: #e6e6e6;
+  background: var(--main-text);
 }
 
 .collapsed .unread_group_header .ts_icon_caret_right, .collapsing .unread_group_header .ts_icon_caret_right {
@@ -2020,15 +2029,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .color_USLACKBOT:not(.nuc), #col_channels ul li:not(.active):not(.away)>.color_USLACKBOT:not(.nuc), #col_channels:not(.show_presence) ul li>.color_USLACKBOT:not(.nuc) {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .comment .member {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .comment .special_formatting_quote .content {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .comment_actions {
@@ -2036,11 +2045,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .comment_actions:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .comment_body {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .comment_meta {
@@ -2048,7 +2057,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .current_status_emoji_picker {
-  border-right-color: #363636;
+  border-right-color: var(--main-dark-highlight);
 }
 
 .current_status_input_for_team_menu .current_status_presets .current_status_presets_section_header .header_label {
@@ -2060,7 +2069,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .day_container .day_divider .day_divider_label {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .day_container .day_divider {
@@ -2069,7 +2078,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .day_container .day_msgs {
-  border-top: 1px solid #363636;
+  border-top: 1px solid var(--main-dark-highlight);
 }
 
 .day_container.unread_day_container .day_msgs {
@@ -2077,16 +2086,16 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .day_divider .day_divider_label {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .day_divider hr, .mention_day_container_div .day_divider hr {
   border-bottom: 0;
-  border-top: 1px solid #363636;
+  border-top: 1px solid var(--main-dark-highlight);
 }
 
 .day_divider, .mention_day_container_div .day_divider {
-  background: #222;
+  background: var(--main-bg-color);
   color: #949494;
 }
 
@@ -2095,15 +2104,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .delete_attachment_link:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .dense_theme ts-message .message_content .message_current_status {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 .dense_theme ts-message {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .dense_theme ts-message.first .message_gutter .timestamp, .dense_theme ts-message.selected .message_gutter .timestamp {
@@ -2115,16 +2124,16 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .developer_apps_functionality_link::before {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 .developer_apps_functionality_link:hover {
-  border-color: #545454;
+  border-color: var(--main-highlight);
   box-shadow: 0 0 6px 0 rgba(130, 130, 130, 0.25);
 }
 
 .dm_badge .dm_badge_meta {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .dm_badge .dm_badge:hover a {
@@ -2144,17 +2153,17 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .edit_comment_form .texty_comment_input, .comment_form .texty_comment_input {
-  background: #545454;
-  border-color: #363636;
-  color: #e6e6e6;
+  background: var(--main-highlight);
+  border-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .edit_comment_form .texty_comment_input.focus, .edit_comment_form .texty_comment_input:hover, .comment_form .texty_comment_input.focus, .comment_form .texty_comment_input:hover {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 .end_div_msg_lim {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   background-image: none;
 }
 
@@ -2184,7 +2193,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_avatar {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 .ent_avatar--bordered::before {
@@ -2196,7 +2205,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_callout__icon_border {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   border-color: #828282;
 }
 
@@ -2205,7 +2214,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_callout__icon--empty, .ent_callout__icon--hidden {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .ent_callout__icon--limit_reached {
@@ -2221,11 +2230,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_callout__meter_bar_border {
-  border-color: #222;
+  border-color: var(--main-bg-color);
 }
 
 .ent_callout__meter_bar_container {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .ent_callout__meter_bar_fill--empty {
@@ -2248,11 +2257,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_callout__title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .ent_copy {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .ent_copy_muted {
@@ -2260,7 +2269,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_csv_popover__footer {
-  background: #363636;
+  background: var(--main-dark-highlight);
   border-top-color: #828282;
 }
 
@@ -2273,7 +2282,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_csv_popover__title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .ent_data_table {
@@ -2284,7 +2293,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .ent_data_table__cell {
   border-bottom-color: #828282;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .ent_data_table__cell--header {
@@ -2292,11 +2301,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_data_table__cell--positive {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .ent_data_table__cell--sortable:hover {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .ent_data_table__cell--sorting {
@@ -2304,7 +2313,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_data_table__column_group {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .ent_data_table__column_group--pinned .ent_data_table__row, .ent_data_table__column_group--right_border {
@@ -2312,11 +2321,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_data_table__data_link, a.ent_data_table__data_link {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .ent_data_table__row--hovered {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .ent_data_table__scrollable--left_shadow::before {
@@ -2336,7 +2345,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_data_table__thead, .ent_data_table--empty_state_wrapper {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .ent_data_table--fix_borders .ent_data_table__row, .ent_data_table--fix_borders .ent_data_table__thead {
@@ -2348,7 +2357,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_empty_state_overlay__content_heading, .ent_empty_state_overlay__content_main_heading {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .ent_graph__data_summary_date_label, .ent_graph__data_summary_point::after {
@@ -2360,7 +2369,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_graph__legend_text {
-  fill: #e6e6e6;
+  fill: var(--main-text);
 }
 
 .ent_graph__svg_container .c3-axis path {
@@ -2381,8 +2390,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_graph__svg_container .c3-tooltip td, .ent_graph__svg_container .c3-tooltip th, .ent_graph__svg_container .c3-tooltip tr {
-  background-color: #363636;
-  color: #e6e6e6;
+  background-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .ent_graph__svg_container .c3-tooltip th {
@@ -2394,11 +2403,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_graph__svg_container .ent_graph__point:not(._expanded_) {
-  fill: #363636 !important;
+  fill: var(--main-dark-highlight) !important;
 }
 
 .ent_graph__svg_container .ent_graph__point._expanded_ {
-  stroke: #363636 !important;
+  stroke: var(--main-dark-highlight) !important;
 }
 
 .ent_graph__svg_container text {
@@ -2410,15 +2419,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_graph_empty__overlay {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 .ent_graph_empty__text {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .ent_graph_header--primary {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .ent_graph_header--secondary {
@@ -2434,7 +2443,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_graph_tabs__tab--selected {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .ent_graph_tabs__tab--selected_ent_violet::after, .ent_graph_tabs__tab--selected_fill_blue::after, .ent_graph_tabs__tab--selected_seafoam_green::after {
@@ -2442,7 +2451,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_header {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .ent_icon_button {
@@ -2450,7 +2459,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_icon_button:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .ent_infographic_container {
@@ -2458,27 +2467,27 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_loading__overlay {
-  background-image: linear-gradient(to bottom, rgba(54, 54, 54, 0.8), #363636);
+  background-image: linear-gradient(to bottom, rgba(54, 54, 54, 0.8), var(--main-dark-highlight));
 }
 
 .ent_modal__title--small {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .ent_modal_background {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .ent_modal_breadcrumb_animated_step {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 .ent_modal_breadcrumb_circle_icon {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .ent_modal_breadcrumb_line {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 .ent_modal_breadcrumb_text {
@@ -2486,30 +2495,30 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_modal_footer {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .ent_modal_title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .ent_table__header {
-  background-color: #222;
+  background-color: var(--main-bg-color);
   border-color: #828282;
 }
 
 .ent_table__header--title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .ent_table_banner__contents {
-  background: #222;
+  background: var(--main-bg-color);
   border-top-color: #828282;
   box-shadow: 0 -5px 15px 0 rgba(0, 0, 0, 0.15);
 }
 
 .ent_table_banner__header {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .ent_table_banner__secondary_text {
@@ -2525,13 +2534,13 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ent_table_customizer_footer {
-  background-color: #222;
+  background-color: var(--main-bg-color);
   border-top-color: #000;
   color: #949494;
 }
 
 .ent_table_customizer_header {
-  border-bottom-color: #222;
+  border-bottom-color: var(--main-bg-color);
 }
 
 .ent_table_customizer_list_item--disabled {
@@ -2547,15 +2556,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .enterprise {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .enterprise_analytics {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .enterprise_org {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .enterprise_search_bar .ent_clear_search_icon {
@@ -2563,11 +2572,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .enterprise_search_bar::before {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .ephemeral.message .message_content {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .extract_expand_text, .extract_expand_icons {
@@ -2575,25 +2584,25 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .feature_sli_file_search #search_filters.all #filter_all {
-  border-bottom-color: #363636;
-  color: #e6e6e6;
+  border-bottom-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .feature_sli_file_search #search_results .file_list_item {
-  background-color: #222;
-  border-color: #545454;
+  background-color: var(--main-bg-color);
+  border-color: var(--main-highlight);
 }
 
 .feature_sli_file_search #search_results_container .heading {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .feature_sli_file_search #search_results_container #search_options {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .feature_sli_file_search #search_results_loading {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .feature_sli_file_search #search_results.all .channel_link, .feature_sli_file_search #search_results.messages .channel_link {
@@ -2601,7 +2610,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .feature_sli_file_search #search_results.all .new_jump_link, .feature_sli_file_search #search_results.messages .new_jump_link {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .feature_sli_file_search #search_results.all .search_message_result_meta, .feature_sli_file_search #search_results.messages .search_message_result_meta {
@@ -2609,28 +2618,28 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .feature_sli_file_search #search_results.all .search_message_result, .feature_sli_file_search #search_results.messages .search_message_result {
-  background-color: #222;
-  border-color: #545454;
+  background-color: var(--main-bg-color);
+  border-color: var(--main-highlight);
 }
 
 .feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child {
-  border-top-color: #545454;
+  border-top-color: var(--main-highlight);
 }
 
 .feature_sli_file_search #search_results.all .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.all .search_result_with_extract:first-child:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.first_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract:first-child:hover {
-  border-top-color: #545454;
+  border-top-color: var(--main-highlight);
 }
 
 .feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group {
-  border-bottom-color: #545454;
+  border-bottom-color: var(--main-highlight);
 }
 
 .feature_sli_file_search #search_results.all .search_result_with_extract.last_extract_message_in_group:hover, .feature_sli_file_search #search_results.messages .search_result_with_extract.last_extract_message_in_group:hover {
-  border-bottom-color: #545454;
+  border-bottom-color: var(--main-highlight);
 }
 
 .feature_sli_file_search #search_results.all .sli_expert_search .channel_link, .feature_sli_file_search #search_results.messages .sli_expert_search .channel_link {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .feature_sli_file_search #search_results.all .sli_expert_search__result {
@@ -2638,7 +2647,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .feature_sli_file_search #search_results.all .sli_expert_search_cta {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .feature_sli_file_search #search_results.all .sli_expert_search_cta:hover {
@@ -2646,13 +2655,13 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .feature_sli_file_search #search_results.all .team_result {
-  background-color: #222;
-  border-color: #545454;
+  background-color: var(--main-bg-color);
+  border-color: var(--main-highlight);
 }
 
 .feature_sli_file_search #search_results.all .top_search_results .search_message_result {
-  background-color: #222;
-  border-color: #545454;
+  background-color: var(--main-bg-color);
+  border-color: var(--main-highlight);
 }
 
 .feature_sli_file_search #search_results.all .top_search_results .search_message_result__channel a {
@@ -2660,19 +2669,19 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .feature_sli_file_search #search_results.all {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .feature_sli_file_search #search_results.all, .feature_sli_file_search #search_results.messages {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .feature_sli_file_search #search_results.files {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .feature_sli_file_search #search_results.files #search_file_list_clear_filter, .feature_sli_file_search #search_results.files #search_file_list_heading {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .file_actions_cog {
@@ -2684,20 +2693,20 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .file_actions_cog:hover {
-  color: #c7c7c7 !important;
+  color: var(--text-hover) !important;
 }
 
 .file_actions_cog:hover {
-  color: #c7c7c7 !important;
+  color: var(--text-hover) !important;
 }
 
 .file_container .c-file__title, .c-file_container .c-file__title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .file_container .CodeMirror .CodeMirror-code>div::before, .file_container .CodeMirror .sssh-line::before, .file_container .sssh-code .CodeMirror-code>div::before, .file_container .sssh-code .sssh-line::before, .c-file_container .CodeMirror .CodeMirror-code>div::before, .c-file_container .CodeMirror .sssh-line::before, .c-file_container .sssh-code .CodeMirror-code>div::before, .c-file_container .sssh-code .sssh-line::before {
-  background-color: #363636;
-  border-right: 1px solid #363636;
+  background-color: var(--main-dark-highlight);
+  border-right: 1px solid var(--main-dark-highlight);
   color: #949494;
 }
 
@@ -2710,8 +2719,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .file_container .preview_actions .btn, .c-file_container .preview_actions .btn {
-  background-color: #363636;
-  color: #e6e6e6 !important;
+  background-color: var(--main-dark-highlight);
+  color: var(--main-text) !important;
 }
 
 .file_container .preview_actions .btn::after, .c-file_container .preview_actions .btn::after {
@@ -2720,7 +2729,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .file_container .preview_actions .btn.preview_show_less_header, .c-file_container .preview_actions .btn.preview_show_less_header {
   background-color: rgba(130, 130, 130, 0.9);
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .file_container .preview_actions .btn.preview_show_less_header::after, .c-file_container .preview_actions .btn.preview_show_less_header::after {
@@ -2728,59 +2737,59 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .file_container .preview_actions .btn.preview_show_less_header:focus, .file_container .preview_actions .btn.preview_show_less_header:hover, .c-file_container .preview_actions .btn.preview_show_less_header:focus, .c-file_container .preview_actions .btn.preview_show_less_header:hover {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .file_container .preview_actions .btn.preview_show_less_header:focus::after, .file_container .preview_actions .btn.preview_show_less_header:hover::after, .c-file_container .preview_actions .btn.preview_show_less_header:focus::after, .c-file_container .preview_actions .btn.preview_show_less_header:hover::after {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 .file_container .preview_show .preview_show_btn, .c-file_container .preview_show .preview_show_btn {
   background: linear-gradient(rgba(84, 84, 84, 0.8), rgba(84, 84, 84, 0.8)), linear-gradient(rgba(130, 130, 130, 0.3), rgba(130, 130, 130, 0.3));
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .file_container, .c-file_container {
   background: #000;
-  border: 1px solid #363636;
-  color: #e6e6e6;
+  border: 1px solid var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .file_container::after, .file_container.post_container::after, .c-file_container::after, .c-file_container.post_container::after {
-  background-image: -webkit-linear-gradient(top, rgba(34, 34, 34, 0) 0, #222 100%);
-  background-image: -moz-linear-gradient(top, rgba(34, 34, 34, 0) 0, #222 100%);
-  background-image: -o-linear-gradient(top, rgba(34, 34, 34, 0) 0, #222 100%);
-  background-image: linear-gradient(top, rgba(34, 34, 34, 0) 0, #222 100%);
+  background-image: -webkit-linear-gradient(top, rgba(34, 34, 34, 0) 0, var(--main-bg-color) 100%);
+  background-image: -moz-linear-gradient(top, rgba(34, 34, 34, 0) 0, var(--main-bg-color) 100%);
+  background-image: -o-linear-gradient(top, rgba(34, 34, 34, 0) 0, var(--main-bg-color) 100%);
+  background-image: linear-gradient(top, rgba(34, 34, 34, 0) 0, var(--main-bg-color) 100%);
 }
 
 .file_container:hover, .file_container:focus, .file_container.file_menu_open, .c-file_container:hover, .c-file_container:focus, .c-file_container.file_menu_open {
-  border-bottom-color: #363636;
-  border-left-color: #363636;
-  border-right-color: #363636;
+  border-bottom-color: var(--main-dark-highlight);
+  border-left-color: var(--main-dark-highlight);
+  border-right-color: var(--main-dark-highlight);
 }
 
 .file_container.file_menu_open .preview_show_less .preview_show_btn, .file_container:focus .preview_show_less .preview_show_btn, .file_container:hover .preview_show_less .preview_show_btn, .c-file_container.file_menu_open .preview_show_less .preview_show_btn, .c-file_container:focus .preview_show_less .preview_show_btn, .c-file_container:hover .preview_show_less .preview_show_btn {
   background: rgba(84, 84, 84, 0.8);
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .file_container.generic_container .file_header_icon .ts_icon, .c-file_container.generic_container .file_header_icon .ts_icon {
-  background: #222;
-  box-shadow: 0 0 0 3px #222;
-  color: #e6e6e6;
+  background: var(--main-bg-color);
+  box-shadow: 0 0 0 3px var(--main-bg-color);
+  color: var(--main-text);
 }
 
 .file_container.generic_container .file_header_icon .ts_icon.snippet, .c-file_container.generic_container .file_header_icon .ts_icon.snippet {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 .file_container.generic_container .file_header_meta .meta_hover, .c-file_container.generic_container .file_header_meta .meta_hover {
   background: #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .file_container.image_container .image_body, .c-file_container.image_container .image_body {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .file_container.image_container .preview_actions .btn, .c-file_container.image_container .preview_actions .btn {
@@ -2788,7 +2797,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .file_container.image_container .preview_actions .btn:focus, .file_container.image_container .preview_actions .btn:hover, .c-file_container.image_container .preview_actions .btn:focus, .c-file_container.image_container .preview_actions .btn:hover {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .file_container.image_container .preview_actions.overflow_preview_actions, .c-file_container.image_container .preview_actions.overflow_preview_actions {
@@ -2801,7 +2810,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .file_header .title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .file_header .title a {
@@ -2813,15 +2822,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .file_header .title a:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .file_header .title a:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .file_header_detailed .member {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .file_header_detailed {
@@ -2833,15 +2842,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .file_list_item .actions a, .file_list_item .actions span {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   border: 1px solid #828282;
   color: #949494;
 }
 
 .file_list_item .actions a:hover {
-  background-color: #222 !important;
+  background-color: var(--main-bg-color) !important;
   border-color: #828282;
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .file_list_item .bullet {
@@ -2858,13 +2867,13 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .file_list_item .icon {
   background: #828282;
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .file_list_item .icon, .file_reference .icon {
   background: #828282;
-  border: 1px solid #545454;
-  color: #e6e6e6 !important;
+  border: 1px solid var(--main-highlight);
+  color: var(--main-text) !important;
 }
 
 .file_list_item .share_info .unshare_link {
@@ -2872,7 +2881,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .file_list_item .share_info .unshare_link:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .file_list_item .title a {
@@ -2884,11 +2893,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .file_list_item {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .file_list_item #share_dialog .actions a, .file_list_item #share_dialog .actions span, .file_list_item.active .actions a, .file_list_item.active .actions span, .file_list_item:active .actions a, .file_list_item:active .actions span, .file_list_item:hover .actions a, .file_list_item:hover .actions span {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .file_list_item #share_dialog .actions, .file_list_item.active .actions, .file_list_item:active .actions, .file_list_item:hover .actions {
@@ -2900,8 +2909,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .file_list_item #share_dialog, .file_list_item.active, .file_list_item:active, .file_list_item:hover {
-  background-color: #363636;
-  border-color: #545454;
+  background-color: var(--main-dark-highlight);
+  border-color: var(--main-highlight);
 }
 
 .file_list_item a {
@@ -2909,11 +2918,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .file_list_item a.member {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .file_list_item.post .preview, .file_list_item.space .preview {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .file_list_item.snippet .snippet_preview {
@@ -2925,11 +2934,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .file_preview_wrapper .file_preview {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .file_preview_wrapper .file_preview:hover {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 .file_reference .icon, .file_list_item .icon, .file_preview {
@@ -2938,22 +2947,22 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .filetype_button .file_download_label {
   background: #828282;
-  border-top: 1px solid #545454;
+  border-top: 1px solid var(--main-highlight);
 }
 
 .filetype_button .file_title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .filetype_button {
   background: #828282;
-  border: 1px solid #545454;
-  color: #e6e6e6 !important;
+  border: 1px solid var(--main-highlight);
+  color: var(--main-text) !important;
 }
 
 .filetype_button:hover .file_download_label {
-  background: #545454;
-  color: #e6e6e6;
+  background: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .filetype_button:hover {
@@ -2961,7 +2970,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .filter_header {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .flexpane_file_title .member, .flexpane_file_title .service_link {
@@ -2973,7 +2982,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .flexpane_file_title .title a:hover, .flexpane_file_title .file_action_list a:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .focusing_input_field space.inactive .unfurl.selected .unfurl-container {
@@ -2982,15 +2991,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .form-actions {
   background-color: #424242;
-  border-top: 1px solid #363636;
+  border-top: 1px solid var(--main-dark-highlight);
 }
 
 .fs_modal_file_viewer_content .aside_close_btn {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .fs_modal_file_viewer_content .aside_panel {
-  background-color: #222;
+  background-color: var(--main-bg-color);
   box-shadow: -1px 0 0 rgba(0, 0, 0, 0.25);
 }
 
@@ -3000,18 +3009,18 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .fs_modal_file_viewer_content .no_comment {
-  background-color: #222;
+  background-color: var(--main-bg-color);
   color: #949494;
 }
 
 .fs_modal_file_viewer_content .viewer .next_btn ts-icon, .fs_modal_file_viewer_content .viewer .previous_btn ts-icon {
-  background: #545454;
+  background: var(--main-highlight);
   box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.25);
 }
 
 .fs_modal_file_viewer_content .viewer .next_btn:focus:not([disabled]), .fs_modal_file_viewer_content .viewer .next_btn:hover:not([disabled]), .fs_modal_file_viewer_content .viewer .previous_btn:focus:not([disabled]), .fs_modal_file_viewer_content .viewer .previous_btn:hover:not([disabled]) {
   background: rgba(130, 130, 130, 0.25);
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .fs_modal_file_viewer_content .viewer .next_btn[disabled]:focus, .fs_modal_file_viewer_content .viewer .next_btn[disabled]:hover, .fs_modal_file_viewer_content .viewer .previous_btn[disabled]:focus, .fs_modal_file_viewer_content .viewer .previous_btn[disabled]:hover {
@@ -3020,23 +3029,23 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .fs_modal_file_viewer_content .viewer {
   background-color: #000;
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .fs_modal_file_viewer_content #file_comment {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .fs_modal_file_viewer_header .btn {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .fs_modal_file_viewer_header .close_btn::after {
-  border-right: 1px solid #545454;
+  border-right: 1px solid var(--main-highlight);
 }
 
 .fs_modal_file_viewer_header .control_btn, .fs_modal_file_viewer_header a.control_btn {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .fs_modal_file_viewer_header .control_btn:focus, .fs_modal_file_viewer_header .control_btn:hover, .fs_modal_file_viewer_header a.control_btn:focus, .fs_modal_file_viewer_header a.control_btn:hover {
@@ -3044,11 +3053,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .fs_modal_file_viewer_header .control_btn:link, .fs_modal_file_viewer_header .control_btn:visited, .fs_modal_file_viewer_header a.control_btn:link, .fs_modal_file_viewer_header a.control_btn:visited {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .fs_modal_file_viewer_header .control_btn.active, .fs_modal_file_viewer_header .control_btn:active, .fs_modal_file_viewer_header a.control_btn.active, .fs_modal_file_viewer_header a.control_btn:active {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 .fs_modal_file_viewer_header .file_size, .fs_modal_file_viewer_header .muted_tooltip_info {
@@ -3060,7 +3069,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .fs_modal_file_viewer_header {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   box-shadow: 0 1px 0 rgba(0, 0, 0, 0.5);
 }
 
@@ -3078,15 +3087,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .help_pages.help_pages .c-form__input, .help_pages.help_pages .c-input {
-  background-color: #222;
-  border-color: #545454;
-  color: #e6e6e6;
+  background-color: var(--main-bg-color);
+  border-color: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .help_pages.help_pages .c-form__notice {
-  background-color: #545454;
+  background-color: var(--main-highlight);
   border-color: #828282;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .help_pages.help_pages .c-form__notice.is-error {
@@ -3094,41 +3103,41 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .help_pages.help_pages .c-nav--footer {
-  border-top-color: #545454;
+  border-top-color: var(--main-highlight);
 }
 
 .help_pages.help_pages .drop_zone {
-  background: #222;
+  background: var(--main-bg-color);
   border-color: #828282;
 }
 
 .help_pages.help_pages .drop_zone_attachment {
-  border-bottom-color: #545454;
+  border-bottom-color: var(--main-highlight);
 }
 
 .help_pages.help_pages .drop_zone_remove_attachment {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .help_pages.help_pages .o-hero__header {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .help_pages.help_pages .o-hero, .help_pages.help_pages .o-hero__header {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .help_pages.help_pages .o-section--feature {
-  background-color: #363636;
-  border-top-color: #545454;
+  background-color: var(--main-dark-highlight);
+  border-top-color: var(--main-highlight);
 }
 
 .help_pages.help_pages a {
-  border-bottom-color: #545454;
+  border-bottom-color: var(--main-highlight);
 }
 
 .help_pages.help_pages p {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .help-block, .help-inline {
@@ -3136,33 +3145,33 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .highlighter_underlay .ghost_text {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .highlighter_underlay .keyword::before {
   background: #828282;
-  border: 1px solid #545454;
-  color: #e6e6e6;
+  border: 1px solid var(--main-highlight);
+  color: var(--main-text);
 }
 
 .highlighter_underlay .modifier::before {
   background: #828282;
-  border: 1px solid #545454;
-  color: #e6e6e6;
+  border: 1px solid var(--main-highlight);
+  color: var(--main-text);
 }
 
 .highlighter_underlay .modifier.incomplete::before {
-  background: #363636;
+  background: var(--main-dark-highlight);
   border: 1px solid #000;
 }
 
 .highlighter_underlay .selected .keyword::before, .highlighter_underlay .selected .modifier::before {
   background: rgba(130, 130, 130, 0.25);
-  border: #545454;
+  border: var(--main-highlight);
 }
 
 .icon_quote {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .icon_search_close {
@@ -3170,7 +3179,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .icon_search_close:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .icon_search_input {
@@ -3182,7 +3191,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .infinite_spinner_bg, .infinite_spinner_blue {
-  stroke: #e6e6e6;
+  stroke: var(--main-text);
 }
 
 .inline_attachment .attachment_footer a, .inline_attachment .attachment_ts a {
@@ -3190,7 +3199,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .inline_attachment .attachment_footer a:active, .inline_attachment .attachment_footer a:hover {
-  color: #c7c7c7 !important;
+  color: var(--text-hover) !important;
 }
 
 .inline_attachment .attachment_footer, .inline_attachment .attachment_ts {
@@ -3198,7 +3207,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .inline_attachment .attachment_ts a:active, .inline_attachment .attachment_ts a:hover {
-  color: #c7c7c7 !important;
+  color: var(--text-hover) !important;
 }
 
 .inline_attachment .iframe_placeholder, .inline_attachment iframe {
@@ -3206,7 +3215,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .inline_attachment a span:active, .inline_attachment a span:hover {
-  color: #c7c7c7 !important;
+  color: var(--text-hover) !important;
 }
 
 .inline_attachment span.attachment_author_name {
@@ -3218,12 +3227,12 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .inline_color_block {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .inline_message_input_container .ql-container {
-  border-color: #545454;
-  color: #e6e6e6;
+  border-color: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .inline_message_input_container .ql-container.focus, .inline_message_input_container .ql-container:active, .inline_message_input_container .ql-container:hover {
@@ -3231,12 +3240,12 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .input_note {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .input-append .add-on, .input-prepend .add-on {
   background-color: #828282;
-  border: 1px solid #545454;
+  border: 1px solid var(--main-highlight);
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
 }
 
@@ -3254,7 +3263,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .lazy_filter_select .lfs_input_container {
-  background-color: #545454;
+  background-color: var(--main-highlight);
   border-color: #000;
 }
 
@@ -3263,13 +3272,13 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .lazy_filter_select .lfs_input_container.active, .lazy_filter_select .lfs_input_container:hover {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 .lazy_filter_select .lfs_list .lfs_item.active {
   background-color: #000;
-  border-color: #363636;
-  color: #e6e6e6;
+  border-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .lazy_filter_select .lfs_list .lfs_item.disabled {
@@ -3277,31 +3286,31 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .lazy_filter_select .lfs_list .lfs_item.selected .c-member__current-status .prevent_copy_paste, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__current-status--small::before, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__display-name, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__name, .lazy_filter_select .lfs_list .lfs_item.selected .c-member__secondary-name {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .lazy_filter_select .lfs_list .lfs_item.selected {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .lazy_filter_select .lfs_list_container {
-  background: #222;
+  background: var(--main-bg-color);
   border-color: #000;
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.5);
 }
 
 .lazy_filter_select .lfs_token {
-  background: #222;
+  background: var(--main-bg-color);
   border: 1px solid #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .lazy_filter_select .lfs_token::after {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .lazy_filter_select.disabled {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 .lazy_filter_select.disabled input.lfs_input {
@@ -3309,27 +3318,27 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .lazy_filter_select.single .lfs_input_container.active::after, .lazy_filter_select.single .lfs_input_container:hover::after {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .left_border {
-  border-left: 1px solid #363636;
+  border-left: 1px solid var(--main-dark-highlight);
 }
 
 .legal-hero .o-hero__header__headline--larger {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .legal-hero {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .legal-hero.v--no-switch, .legal-hero .o-hero__header {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .legal-main .t-contains-subtle-links a:not(.c-button) {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .legal-main .t-contains-subtle-links a:not(.c-button):active, .legal-main .t-contains-subtle-links a:not(.c-button):focus, .legal-main .t-contains-subtle-links a:not(.c-button):hover {
@@ -3337,21 +3346,21 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .legal-main {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .legal-main a {
-  border-bottom-color: #545454;
+  border-bottom-color: var(--main-highlight);
 }
 
 .legal-main p {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .legal-main.v--no-switch {
-  background-color: #363636;
-  border-bottom-color: #545454;
-  border-top-color: #545454;
+  background-color: var(--main-dark-highlight);
+  border-bottom-color: var(--main-highlight);
+  border-top-color: var(--main-highlight);
 }
 
 .light_theme ts-message .comment::before {
@@ -3359,15 +3368,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .light_theme ts-message .message_content .message_sender, .light_theme ts-message .message_content .meta .message_sender:hover {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .light_theme ts-message {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .link_billing_statement {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .link_invoice_id, .link_statement_id {
@@ -3375,7 +3384,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .loading #loading-zone {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .loading_hash_animation img {
@@ -3388,7 +3397,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .member_mentions_options {
   background-color: #000;
-  border-top: 1px solid #363636;
+  border-top: 1px solid var(--main-dark-highlight);
 }
 
 .member_meta {
@@ -3397,7 +3406,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .mention_day_container_div .day_divider::before {
   background: none;
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 .mention_rxn .mention_rxn_summary .member_preview_link, .mention_rxn .mention_rxn_summary .mention_rxn_summary_members {
@@ -3405,11 +3414,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .mention_rxn .mention_rxn_summary {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .menu .menu_content {
-  background: #363636 !important;
+  background: var(--main-dark-highlight) !important;
 }
 
 .menu .menu_filter_container .icon_close {
@@ -3421,7 +3430,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .menu .menu_filter_container {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .menu .menu_filter_container input.menu_filter {
@@ -3429,11 +3438,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .menu .menu_filter_container input.menu_filter:focus {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .menu .section_header .header_label {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   color: #949494;
 }
 
@@ -3442,25 +3451,25 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .menu {
-  background: #363636;
-  border: 1px solid #222;
+  background: var(--main-dark-highlight);
+  border: 1px solid var(--main-bg-color);
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .menu #menu_footer .menu_footer {
   background: #000;
-  border-top: 1px solid #363636;
+  border-top: 1px solid var(--main-dark-highlight);
 }
 
 .menu #menu_header .menu_close {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .menu #menu_header .menu_simple_header {
   background: #000;
-  border-color: #363636;
-  color: #e6e6e6;
+  border-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .menu #menu_header .menu_simple_header a {
@@ -3468,31 +3477,31 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .menu #menu_header .menu_simple_header a:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .menu #menu_list_container #menu_list .menu_list_item a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .menu #menu_list_container #menu_list .menu_list_item.active a {
-  background: #545454;
-  color: #e6e6e6;
+  background: var(--main-highlight);
+  color: var(--main-text);
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
 }
 
 .menu #monkey_scroll_wrapper_for_menu_items_scroller {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 .menu input {
-  background: #363636;
-  border: 1px solid #545454;
+  background: var(--main-dark-highlight);
+  border: 1px solid var(--main-highlight);
 }
 
 .menu textarea {
-  background: #363636;
-  border: 1px solid #545454;
+  background: var(--main-dark-highlight);
+  border: 1px solid var(--main-highlight);
 }
 
 .menu ul li .menu_item_details {
@@ -3500,13 +3509,13 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .menu ul li a {
-  background: #363636;
+  background: var(--main-dark-highlight);
   border-bottom: 0;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .menu ul li a:not(.inline_menu_link) {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .menu ul li a.delete_link {
@@ -3522,17 +3531,17 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .menu ul li.divider {
-  border-bottom-color: #222;
+  border-bottom-color: var(--main-bg-color);
 }
 
 .menu ul li.highlighted a .menu_item_details, .menu ul li.highlighted a .prefix, .menu ul li.highlighted a i, .menu ul li.highlighted a ts-icon {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .menu ul li.highlighted a {
-  background: #222;
+  background: var(--main-bg-color);
   border-bottom-color: #000;
-  color: #e6e6e6;
+  color: var(--main-text);
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
 }
 
@@ -3541,22 +3550,22 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .menu_launcher_large {
-  border-color: #222;
+  border-color: var(--main-bg-color);
 }
 
 .menu_launcher, .menu_launcher_large {
-  background-color: #545454;
-  border-color: #222 !important;
-  color: #e6e6e6;
+  background-color: var(--main-highlight);
+  border-color: var(--main-bg-color) !important;
+  color: var(--main-text);
 }
 
 .menu_member_footer {
   background: #000;
-  border-top: 1px solid #545454;
+  border-top: 1px solid var(--main-highlight);
 }
 
 .menu_member_footer #menu_member_dm_input p {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .menu_member_footer p {
@@ -3564,7 +3573,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .menu_member_header .member_details .member_name_and_presence .member_name {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .menu_member_header .member_details .member_name_and_presence .presence.away {
@@ -3572,7 +3581,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .menu_member_header .member_details .member_name_and_presence {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .menu_member_header .member_details .member_restriction a, .menu_member_header .member_details .member_timezone_value a {
@@ -3580,7 +3589,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .menu_member_header .member_details .member_restriction a:hover, .menu_member_header .member_details .member_timezone_value a:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .menu_member_header .member_details .member_restriction, .menu_member_header .member_details .member_timezone_value {
@@ -3592,7 +3601,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .menu_member_header .member_details_divider {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .menu_member_header {
@@ -3600,13 +3609,13 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .menu:not(.keyboard_active) ul li:hover:not(.disabled) a .menu_item_details, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a .prefix, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a i, .menu:not(.keyboard_active) ul li:hover:not(.disabled) a ts-icon {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .menu:not(.keyboard_active) ul li:hover:not(.disabled) a {
-  background: #222;
+  background: var(--main-bg-color);
   border-bottom-color: #000;
-  color: #e6e6e6;
+  color: var(--main-text);
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
 }
 
@@ -3615,21 +3624,21 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .menu.avatar_menu ul li a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .menu.avatar_menu ul li a img, .menu.avatar_menu ul li a ts-icon {
-  background-color: #545454;
+  background-color: var(--main-highlight);
   color: #949494;
 }
 
 .menu.avatar_menu ul li:hover ts-icon {
-  background: #545454;
-  color: #e6e6e6;
+  background: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .menu.avatar_menu:not(.keyboard_active) ul li:hover:not(.disabled) a ts-icon {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .message_cell.disabled {
@@ -3641,33 +3650,33 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .message--focus .file_container .preview_show.preview_show_less .preview_show_btn {
-  background: #545454;
-  color: #e6e6e6;
+  background: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .messages_banner {
-  color: #e6e6e6;
+  color: var(--main-text);
   text-shadow: 0 1px rgba(0, 0, 0, 0.15);
 }
 
 .messages_banner a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .messages_banner a:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .messages_header {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .meta.meta_feature_fix_files .file_new_window_link:hover .file_inline_icon, .dense_meta.meta_feature_fix_files .file_new_window_link:hover .file_inline_icon {
-  color: #c7c7c7 !important;
+  color: var(--text-hover) !important;
 }
 
 .meta.meta_feature_fix_files .file_new_window_link:hover, .dense_meta.meta_feature_fix_files .file_new_window_link:hover {
-  color: #c7c7c7 !important;
+  color: var(--text-hover) !important;
 }
 
 .meta.meta_feature_fix_files .member, .dense_meta.meta_feature_fix_files .member {
@@ -3675,7 +3684,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title, .meta.msg_inline_img_toggler .msg_inline_file_preview_title, .dense_meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title, .dense_meta.msg_inline_img_toggler .msg_inline_file_preview_title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title:hover, .meta.msg_inline_img_toggler .msg_inline_file_preview_title:hover, .dense_meta.msg_inline_file_preview_toggler .msg_inline_file_preview_title:hover, .dense_meta.msg_inline_img_toggler .msg_inline_file_preview_title:hover {
@@ -3683,7 +3692,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .meta.msg_inline_file_preview_toggler .ts_icon.msg_inline_media_toggler:hover, .meta.msg_inline_img_toggler .ts_icon.msg_inline_media_toggler:hover, .dense_meta.msg_inline_file_preview_toggler .ts_icon.msg_inline_media_toggler:hover, .dense_meta.msg_inline_img_toggler .ts_icon.msg_inline_media_toggler:hover {
-  color: #c7c7c7 !important;
+  color: var(--text-hover) !important;
 }
 
 .meta.msg_inline_file_preview_toggler a[data-file-id], .meta.msg_inline_img_toggler a[data-file-id], .dense_meta.msg_inline_file_preview_toggler a[data-file-id], .dense_meta.msg_inline_img_toggler a[data-file-id] {
@@ -3695,23 +3704,23 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .meta.msg_inline_file_preview_toggler:hover a[data-file-id], .meta.msg_inline_img_toggler:hover a[data-file-id], .dense_meta.msg_inline_file_preview_toggler:hover a[data-file-id], .dense_meta.msg_inline_img_toggler:hover a[data-file-id] {
-  color: #c7c7c7 !important;
+  color: var(--text-hover) !important;
 }
 
 .meta.msg_inline_file_preview_toggler:hover, .meta.msg_inline_img_toggler:hover, .dense_meta.msg_inline_file_preview_toggler:hover, .dense_meta.msg_inline_img_toggler:hover {
-  color: #c7c7c7 !important;
+  color: var(--text-hover) !important;
 }
 
 .mini, .dull_grey, .flat_grey, .blue_link, .blue_fill, .slate_blue, .charcoal_grey, .indifferent_grey, .ts_tip_tip .subtle_silver {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .modal .close, .modal label {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .modal {
-  background-color: #222;
+  background-color: var(--main-bg-color);
   border: 0;
   box-shadow: 0 1px 10px rgba(0, 0, 0, 0.5);
 }
@@ -3721,19 +3730,19 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .modal-backdrop {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .modal-footer {
-  background: padding-box #222;
+  background: padding-box var(--main-bg-color);
   border-top: 1px solid transparent;
   box-shadow: none;
 }
 
 .modal-header {
   background: padding-box #000;
-  border-bottom: 1px solid #363636;
-  color: #e6e6e6;
+  border-bottom: 1px solid var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .monkey_scroll_bar {
@@ -3749,7 +3758,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .monkey_scroll_handle_inner {
-  background: #545454;
+  background: var(--main-highlight);
   border: 1px solid #828282;
 }
 
@@ -3762,15 +3771,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .msg_inline_attachment_collapser:hover, .msg_inline_attachment_expander:hover, .msg_inline_img_collapser:hover, .msg_inline_img_expander:hover, .msg_inline_media_toggler:hover, .msg_inline_room_preview_collapser:hover, .msg_inline_room_preview_expander:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .msg_inline_attachment_column.column_border {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 .msg_inline_img {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 .msg_inline_img_holder .msg_inline_img {
@@ -3790,7 +3799,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .msg_inline_video_buttons_div a {
-  color: #e6e6e6;
+  color: var(--main-text);
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
 }
 
@@ -3804,35 +3813,35 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .no_results {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .no_touch .accordion_section h4 a:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .no_touch input:hover, .no_touch select:hover, .no_touch textarea:hover {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 .no_touch label.select:hover select {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 .no_touch label.select:not(.disabled):hover::after {
-  color: #363636;
+  color: var(--main-dark-highlight);
 }
 
 .notification_prefs_icon::before {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .off_white_bg, .neutral_white_bg {
-  background-color: #363636 !important;
+  background-color: var(--main-dark-highlight) !important;
 }
 
 .p-apps_browser__app {
-  border-top-color: #545454;
+  border-top-color: var(--main-highlight);
 }
 
 .p-apps_browser__app_description {
@@ -3840,22 +3849,22 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-apps_browser__app_info {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-apps_browser__app--selected {
-  background: #363636;
+  background: var(--main-dark-highlight);
   border-color: #828282;
 }
 
 .p-apps_browser__apps_list--loading::before {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .p-apps_browser__browse_apps, .p-apps_browser__app_action {
-  background-color: #545454;
+  background-color: var(--main-highlight);
   border-color: #828282;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-apps_browser__browse_apps:active, .p-apps_browser__app_action:active {
@@ -3864,21 +3873,21 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .p-apps_browser__browse_apps:hover, .p-apps_browser__browse_apps:focus, .p-apps_browser__app_action:hover, .p-apps_browser__app_action:focus {
   background-color: #828282;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-apps_browser__category_header {
-  background: #222;
+  background: var(--main-bg-color);
   color: #949494;
 }
 
 .p-apps_browser__category_section--tutorial .p-apps_browser__app {
-  border-color: #545454;
+  border-color: var(--main-highlight);
   box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.15);
 }
 
 .p-apps_browser__category_section--tutorial .p-apps_browser__app--selected {
-  background: #363636;
+  background: var(--main-dark-highlight);
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.25);
 }
 
@@ -3891,22 +3900,22 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-app_space_profile__info {
-  border-bottom: 1px solid #222;
-  background-color: #222;
+  border-bottom: 1px solid var(--main-bg-color);
+  background-color: var(--main-bg-color);
 }
 
 .p-app_space_profile__side--links {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .p-app_space_profile__slash_commands {
-  border-top: 1px solid #545454;
-  border-bottom: 1px solid #545454;
-  background: #222;
+  border-top: 1px solid var(--main-highlight);
+  border-bottom: 1px solid var(--main-highlight);
+  background: var(--main-bg-color);
 }
 
 .p-app_space_profile__slash_command:last-child {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .p-app_space_profile__slash_command strong {
@@ -3914,7 +3923,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-app_space_profile__slash_command_desc {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .p-app_space__subheader__helper {
@@ -3924,15 +3933,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 .p-app_space_profile__screenshots {
   border-top: 1px solid #949494;
   border-bottom: 1px solid #949494;
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .p-archives_banner {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .p-archives_banner__data_range {
-  background-color: #222;
+  background-color: var(--main-bg-color);
   color: #f8f8f8;
 }
 
@@ -3941,20 +3950,20 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-block_kit_date_picker_calendar_wrapper .c-calendar_view_header__title_btn {
-  background: #545454;
-  border-color: #363636;
-  color: #e6e6e6;
+  background: var(--main-highlight);
+  border-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .p-block_kit_date_picker_calendar_wrapper .c-date_picker_calendar__date--disabled, .p-block_kit_date_picker_calendar_wrapper .c-mini_calendar__month_button:disabled {
-  background: #545454;
+  background: var(--main-highlight);
   color: #828282;
 }
 
 .p-block_kit_date_picker_calendar_wrapper {
-  background: #363636;
-  border-color: #545454;
-  color: #e6e6e6;
+  background: var(--main-dark-highlight);
+  border-color: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .p-channel_insights .c-member__title {
@@ -3962,7 +3971,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-channel_insights__activity {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .p-channel_insights__activity_bar {
@@ -3974,25 +3983,25 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-channel_insights__channel .channel_link {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-channel_insights__date_heading span {
-  background-color: #222;
+  background-color: var(--main-bg-color);
   color: #949494;
 }
 
 .p-channel_insights__date_heading span {
-  background-color: #222;
-  color: #e6e6e6;
+  background-color: var(--main-bg-color);
+  color: var(--main-text);
 }
 
 .p-channel_insights__date_heading::before {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .p-channel_insights__date_heading::before {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 .p-channel_insights__drawer_title {
@@ -4004,7 +4013,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-channel_insights__item--user .member_preview_link, .p-channel_insights__item--user .message_sender {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .p-channel_insights__member_count .ts_icon_user {
@@ -4016,29 +4025,29 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-channel_insights__message ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) {
-  background-color: #222;
-  border-color: #363636;
+  background-color: var(--main-bg-color);
+  border-color: var(--main-dark-highlight);
 }
 
 .p-channel_insights__message ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) {
-  background-color: #222;
-  border-color: #545454;
+  background-color: var(--main-bg-color);
+  border-color: var(--main-highlight);
 }
 
 .p-channel_insights__message--truncate::before {
-  background: linear-gradient(180deg, transparent, #222 90%);
+  background: linear-gradient(180deg, transparent, var(--main-bg-color) 90%);
 }
 
 .p-channel_insights__message--truncate::before {
-  background: linear-gradient(180deg, transparent, #363636 90%);
+  background: linear-gradient(180deg, transparent, var(--main-dark-highlight) 90%);
 }
 
 .p-channel_insights__section:not(.p-channel_insights__section--no_border) {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .p-channel_insights__title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-channel_insights__user_title {
@@ -4046,7 +4055,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-channel_insights_activity_bar_container:hover .p-channel_insights__activity_bar {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 .p-channel_insights_activity_bar_container:hover {
@@ -4054,12 +4063,12 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-channel_sidebar .c-custom_scrollbar__thumb_vertical, .p-channel_sidebar .c-scrollbar__bar {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 .p-channel_sidebar {
-  background-color: #222 !important;
-  color: #e6e6e6;
+  background-color: var(--main-bg-color) !important;
+  color: var(--main-text);
 }
 
 .p-channel_sidebar__badge, .p-channel_sidebar__banner--mentions {
@@ -4071,23 +4080,23 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-channel_sidebar__channel--im.p-channel_sidebar__channel--selected .c-presence, .p-channel_sidebar__channel--im-slackbot.p-channel_sidebar__channel--selected::before {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-channel_sidebar__channel--selected, .p-channel_sidebar__channel--selected:link, .p-channel_sidebar__channel--selected:visited, .p-channel_sidebar__channel--selected:hover, .p-channel_sidebar__link--selected, .p-channel_sidebar__link--selected:link, .p-channel_sidebar__link--selected:visited, .p-channel_sidebar__link--selected:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-channel_sidebar__channel--selected, .p-channel_sidebar__link--selected {
-  background: #545454 !important;
+  background: var(--main-highlight) !important;
 }
 
 .p-channel_sidebar__channel--selected::before, .p-channel_sidebar__channel--selected:hover::before, .p-channel_sidebar__channel--selected::after, .p-channel_sidebar__channel--selected:hover::after {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-channel_sidebar__channel--selected:hover, .p-channel_sidebar__link--selected:hover {
-  background: #545454 !important;
+  background: var(--main-highlight) !important;
 }
 
 .p-channel_sidebar__channel--unread:not(.p-channel_sidebar__channel--muted):not(.p-channel_sidebar__channel--selected) .p-channel_sidebar__name, .p-channel_sidebar__link--unread .p-channel_sidebar__name, .p-channel_sidebar__link--invites:not(.p-channel_sidebar__link--dim) .p-channel_sidebar__name, .p-channel_sidebar__section_heading_label--clickable:hover, .p-channel_sidebar__quickswitcher:hover {
@@ -4099,7 +4108,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-channel_sidebar__channel:hover, .p-channel_sidebar__link:hover {
-  background: #222 !important;
+  background: var(--main-bg-color) !important;
 }
 
 .p-channel_sidebar__close_container:hover {
@@ -4107,7 +4116,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-channel_sidebar__header {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .p-channel_sidebar__jumper {
@@ -4115,7 +4124,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-channel_sidebar__link--selected::before, .p-channel_sidebar__link--selected::after {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-channel-options--content_text {
@@ -4131,8 +4140,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-degraded_list__loading {
-  background-color: #222;
-  color: #e6e6e6;
+  background-color: var(--main-bg-color);
+  color: var(--main-text);
 }
 
 .p-detail_arrow_icon {
@@ -4140,25 +4149,25 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-detail_arrow_icon:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-detail_dangerous_scope {
   border-left-color: #bf360c;
-  border-right-color: #545454;
+  border-right-color: var(--main-highlight);
 }
 
 .p-detail_permissions {
-  background: #363636;
-  border-color: #545454;
+  background: var(--main-dark-highlight);
+  border-color: var(--main-highlight);
 }
 
 .p-detail_scope {
-  box-shadow: inset 0 1px 0 0 #545454;
+  box-shadow: inset 0 1px 0 0 var(--main-highlight);
 }
 
 .p-detail_scope:last-child {
-  border-bottom-color: #545454;
+  border-bottom-color: var(--main-highlight);
 }
 
 .p-dnd_preferences__tz_label {
@@ -4171,11 +4180,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-download_item__actions {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .p-download_item__container .p-download_item__actions {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .p-download_item__container .p-download_item__link__open, .p-download_item__container .p-download_item__link__retry, .p-download_item__container .p-download_item__link__show {
@@ -4183,35 +4192,35 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-download_item__container .p-download_item__name_row {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-download_item__container .p-download_item__name_row {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-download_item__link--open, .p-download_item__link--retry, .p-download_item__link--show {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-downloads_list__shift_hint {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0), #222 25%, #222);
-  color: #e6e6e6;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0), var(--main-bg-color) 25%, var(--main-bg-color));
+  color: var(--main-text);
 }
 
 .p-downloads_list__shift_hint {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0), #363636 25%, #363636);
-  color: #e6e6e6;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0), var(--main-dark-highlight) 25%, var(--main-dark-highlight));
+  color: var(--main-text);
 }
 
 .p-emoji_picker {
   background: #000 !important;
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .p-emoji_picker__content:hover .p-emoji_picker__skintone_btn_container {
-  background: #222;
-  border-color: #222;
+  background: var(--main-bg-color);
+  border-color: var(--main-bg-color);
 }
 
 .p-emoji_picker__emoji_deluxe_label {
@@ -4224,7 +4233,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .p-emoji_picker__footer {
   background: #000;
-  border-top-color: #363636;
+  border-top-color: var(--main-dark-highlight);
 }
 
 .p-emoji_picker__group_tab {
@@ -4232,14 +4241,14 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-emoji_picker__group_tab--active {
-  background: #545454;
+  background: var(--main-highlight);
   border-bottom-color: #424242;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-emoji_picker__group_tab:hover {
-  background: #363636;
-  color: #c7c7c7;
+  background: var(--main-dark-highlight);
+  color: var(--text-hover);
 }
 
 .p-emoji_picker__group_tabs {
@@ -4247,7 +4256,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-emoji_picker__heading, .p-emoji_picker__list_container, .p-emoji_picker__input_container {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .p-emoji_picker__icon_search {
@@ -4288,15 +4297,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .p-emoji_picker__preview_text {
   background: #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-emoji_picker__skintone_options {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .p-emoji_picker__tip {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-emoji_picker__tip i, .p-emoji_picker__no_results i {
@@ -4332,36 +4341,36 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-file_details__name, .p-file_details__share_channel {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-file_list__file_type_select .c-input_select__selected_value--placeholder {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-file_list__file.c-pillow_file_container--full_width:hover {
-  background: #545454;
-  border-color: #545454;
+  background: var(--main-highlight);
+  border-color: var(--main-highlight);
 }
 
 .p-file_list__file.c-pillow_file_container, .p-file_list__file.c-pillow_file_container--full_width {
-  background: #363636;
-  border-color: #363636;
-  color: #e6e6e6;
+  background: var(--main-dark-highlight);
+  border-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .p-file_list__filters {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 .p-file_list, .p-file_list__filters {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 .p-flexpane_header {
-  background: #363636;
-  border-color: #545454;
-  color: #e6e6e6;
+  background: var(--main-dark-highlight);
+  border-color: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .p-flexpane_header__control {
@@ -4369,43 +4378,43 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-help_modal__footer {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .p-help_modal__shortcuts__button {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   color: #f8f8f8;
 }
 
 .p-help_search__list__item:focus {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .p-message_pane .c-message_list.c-virtual_list--scrollbar>.c-scrollbar__hider {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .p-message_pane .c-message_list.c-virtual_list--scrollbar>.c-scrollbar__hider::before {
-  background: #222;
-  border-bottom: 1px solid #363636;
+  background: var(--main-bg-color);
+  border-bottom: 1px solid var(--main-dark-highlight);
 }
 
 .p-message_pane .p-message_pane__top_banners:not(:empty)+div .c-message_list:not(.c-virtual_list--scrollbar):before, .p-message_pane .p-message_pane__top_banners:not(:empty)+div .c-message_list.c-virtual_list--scrollbar>.c-scrollbar__hider:before {
-  box-shadow: 0 32px #222;
+  box-shadow: 0 32px var(--main-bg-color);
 }
 
 .p-message_pane__foreword__description, .p-message_pane__limited_history_alert {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-message_pane__limited_history_foreword {
-  background: #363636;
+  background: var(--main-dark-highlight);
   background-image: none;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-message_pane__unread_banner__banner {
-  background: #545454;
+  background: var(--main-highlight);
   text-shadow: 0 1px rgba(0, 0, 0, 0.15);
 }
 
@@ -4414,39 +4423,39 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-oauth_nav__team-switcher .menu_launcher {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 .p-oauth_nav__team-switcher .menu_launcher:hover {
-  border: #545454;
+  border: var(--main-highlight);
 }
 
 .p-oauth_page__title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-oauth_page_single_channel_picker {
-  border-bottom-color: #363636;
+  border-bottom-color: var(--main-dark-highlight);
 }
 
 .p-oauth_page, .p-oauth_page--error {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .p-prefs_modal__channel_overrides_row__setting {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .p-prefs_modal__content_container p {
-  color: #e6e6e6
+  color: var(--main-text)
 }
 
 .p-prefs_modal .c-fullscreen_modal__body {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .p-prefs_modal__notification_example.p-prefs_modal__notification_example--mac {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 .p-prefs_modal__radiogroup label.p-prefs_modal__radiogroup--selected {
@@ -4454,9 +4463,9 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-search_filter__datepicker_trigger {
-  background: #363636;
-  border-color: #545454;
-  color: #e6e6e6;
+  background: var(--main-dark-highlight);
+  border-color: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .p-search_filter__datepicker_trigger:hover {
@@ -4464,16 +4473,16 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-search_filter__more_link {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-search_filter__title_text {
-  background: #363636;
-  color: #e6e6e6;
+  background: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .p-share_dialog_message_input {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-shortcuts_flexpane__section_description {
@@ -4485,7 +4494,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-shortcuts_flexpane__shortcut_hoverable .p-shortcuts_flexpane__shortcut_title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-shortcuts_flexpane__shortcut_title {
@@ -4505,24 +4514,24 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-shortcuts_flexpane__title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-threads_footer__input .p-message_input_field, .p-threads_footer__input--legacy .p-message_input_field {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 .p-threads_footer__input--legacy .p-message_input_file_button {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 .p-threads_view__divider_label {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .p-threads_view__default_background, .p_threads_view_load_older_button,
 .p_threads_view_load_older_button .p-threads_footer__input .p-message_input_file_button {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 .p-threads_view_root, .p-threads_view__footer, .p_threads_view_load_older_button, .p-threads_view_reply {
@@ -4538,7 +4547,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p_threads_view_load_newer_button, .p-threads_view_header, .p-threads_view__footer, .p_threads_view_load_older_button {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .p-threads_view_header__participant_list, .p-threads_view_header__channel_name {
@@ -4550,11 +4559,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-threads_view_scroller_div {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .p-threads_view_scroller_div:not(.loading)::before {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .p-threads_view_scroller_div.loading::before {
@@ -4562,12 +4571,12 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-threads_view_scroller_div .threads_caught_up_divider .divider_line, .p-threads_view__divider_line {
-  border-top: 1px solid #363636;
+  border-top: 1px solid var(--main-dark-highlight);
 }
 
 .p-threads_view_scroller_div .threads_caught_up_divider .divider_label {
-  background: #545454;
-  color: #e6e6e6;
+  background: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .p-threads_view_scroller_div.loading {
@@ -4575,15 +4584,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .p-threads_view_scroller_div.loading::before {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .p-threads_view.new_banner_is_showing::before {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .p-unreads_view__header {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .p-unreads_view__header__channel_name {
@@ -4591,11 +4600,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .page_apps_directory_home .nav_title {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .page_apps_directory_home {
-  background-color: #222 !important;
+  background-color: var(--main-bg-color) !important;
 }
 
 .page_apps_directory_home__search .apps_search_input__body {
@@ -4607,7 +4616,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .page_faq h3, .page_scim h3 {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .pager .disabled>a, .pager .disabled>span {
@@ -4615,9 +4624,9 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .pager li>a, .pager li>span {
-  background-color: #222;
+  background-color: var(--main-bg-color);
   background-image: none;
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
   color: #949494;
 }
 
@@ -4638,24 +4647,24 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .pagination ul>.disabled>a {
-  background: #363636;
+  background: var(--main-dark-highlight);
   color: #949494;
 }
 
 .pagination ul>.disabled>a:focus {
-  background: #363636;
-  color: #c7c7c7;
+  background: var(--main-dark-highlight);
+  color: var(--text-hover);
 }
 
 .pagination ul>.disabled>span {
-  background: #363636;
+  background: var(--main-dark-highlight);
   color: #949494;
 }
 
 .pagination ul>li>a, .pagination ul>li>span {
-  background: #363636;
+  background: var(--main-dark-highlight);
   border: 1px solid #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .pagination ul>li>a:focus {
@@ -4663,35 +4672,35 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .para_menu .format .options .arrow-shadow::after {
-  background-color: #363636;
-  box-shadow: 0 0 0 1px #545454;
+  background-color: var(--main-dark-highlight);
+  box-shadow: 0 0 0 1px var(--main-highlight);
 }
 
 .para_menu .format .options .arrow-shadow.bottom::after {
-  box-shadow: 1px 1px 0 0 #545454;
+  box-shadow: 1px 1px 0 0 var(--main-highlight);
 }
 
 .para_menu .format .options .arrow::after {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .para_menu .format .options .content {
-  background-color: #363636;
-  box-shadow: 0 0 0 1px #545454, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25);
+  background-color: var(--main-dark-highlight);
+  box-shadow: 0 0 0 1px var(--main-highlight), 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25);
 }
 
 .para_menu .format .options .content ul:first-child {
-  border-bottom: 1px solid #363636;
+  border-bottom: 1px solid var(--main-dark-highlight);
 }
 
 .para_menu .format .options.show .tooltip>div {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15);
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .para_menu .format .options.show .tooltip span {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 .para_menu .insert .tip {
@@ -4699,17 +4708,17 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .para_menu .insert .tooltip .arrow-shadow::after {
-  background-color: #363636;
-  box-shadow: 0 0 0 1px #545454;
+  background-color: var(--main-dark-highlight);
+  box-shadow: 0 0 0 1px var(--main-highlight);
 }
 
 .para_menu .insert .tooltip .arrow::after {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .para_menu .insert .tooltip .content {
-  background-color: #363636;
-  box-shadow: 0 0 0 1px #545454, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25);
+  background-color: var(--main-dark-highlight);
+  box-shadow: 0 0 0 1px var(--main-highlight), 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25);
 }
 
 .para_menu .options a span {
@@ -4717,12 +4726,12 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .para_menu .options a:hover {
-  border: 1px solid #545454;
+  border: 1px solid var(--main-highlight);
 }
 
 .para_menu .options a.active {
   background-color: #424242;
-  border: 1px solid #363636;
+  border: 1px solid var(--main-dark-highlight);
 }
 
 .para_menu .options a.active span {
@@ -4738,70 +4747,70 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .pickmeup .pmu-instance .pmu-button {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover {
-  background: #545454;
-  color: #e6e6e6;
+  background: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .pickmeup .pmu-instance .pmu-day-of-week {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .pickmeup .pmu-instance .pmu-day-of-week * {
-  border: 1px solid #363636;
+  border: 1px solid var(--main-dark-highlight);
 }
 
 .pickmeup .pmu-instance .pmu-days * {
-  border: 1px solid #363636;
+  border: 1px solid var(--main-dark-highlight);
 }
 
 .pickmeup .pmu-instance .pmu-disabled {
-  background: #222;
+  background: var(--main-bg-color);
   color: #949494;
 }
 
 .pickmeup .pmu-instance .pmu-disabled:hover {
-  background: #222;
+  background: var(--main-bg-color);
   color: #949494;
 }
 
 .pickmeup .pmu-instance .pmu-months *, .pickmeup .pmu-instance .pmu-years * {
-  border: 1px solid #363636;
+  border: 1px solid var(--main-dark-highlight);
 }
 
 .pickmeup .pmu-instance .pmu-not-in-month {
-  background: #222;
+  background: var(--main-bg-color);
   color: #949494;
 }
 
 .pickmeup .pmu-instance .pmu-not-in-month.pmu-selected {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 .pickmeup .pmu-instance .pmu-selected {
-  background: #545454;
-  color: #e6e6e6;
+  background: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .pickmeup .pmu-instance .pmu-today-border {
-  border: 2px solid #545454 !important;
+  border: 2px solid var(--main-highlight) !important;
   color: #828282 !important;
 }
 
 .pickmeup .pmu-instance .pmu-today.pmu-selected .pmu-today-border, .pickmeup .pmu-instance .pmu-today:hover .pmu-today-border {
   background: #828282;
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .pickmeup .pmu-instance .pmu-today.pmu-selected, .pickmeup .pmu-instance .pmu-today:hover {
-  background: #363636 !important;
+  background: var(--main-dark-highlight) !important;
 }
 
 .pickmeup .pmu-instance nav :first-child :hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .pickmeup .pmu-instance nav {
@@ -4809,8 +4818,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .pickmeup {
-  background: #222;
-  border: 1px solid #363636;
+  background: var(--main-bg-color);
+  border: 1px solid var(--main-dark-highlight);
   box-shadow: 0 1px 5px rgba(0, 0, 0, 0.15);
 }
 
@@ -4827,7 +4836,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .pinned_item .pinned_message_text .pin_truncate_fade {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .pinned_item .remove_pin {
@@ -4835,11 +4844,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .pinned_item .remove_pin:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .pinned_item {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .pinned_item.delete_mode {
@@ -4851,57 +4860,57 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .plastic_row .description {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .plastic_row .icon {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .plastic_row h3 {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .plastic_row h4 a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .plastic_row:active .chevron {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .plastic_row:active {
-  background: #222;
+  background: var(--main-bg-color);
   border-color: #000;
 }
 
 .plastic_typeahead {
-  background: #363636;
-  border: 1px solid #363636;
+  background: var(--main-dark-highlight);
+  border: 1px solid var(--main-dark-highlight);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25);
 }
 
 .plastic_typeahead_item {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .plastic_typeahead_item+.plastic_typeahead_item {
-  border-top: 1px solid #545454;
+  border-top: 1px solid var(--main-highlight);
 }
 
 .plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover {
   background: #000;
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .plastic_typeahead_item:not(.plastic_typeahead_item_no_results):not(.is_active):hover+.plastic_typeahead_item {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .plastic_typeahead_item:not(.plastic_typeahead_item_no_results).is_active {
-  background-color: #222;
-  border-top-color: #363636;
-  color: #e6e6e6;
+  background-color: var(--main-bg-color);
+  border-top-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .plastic_typeahead_item:not(.plastic_typeahead_item_no_results).is_active ts-icon {
@@ -4909,8 +4918,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .popover_menu .arrow_shadow::after {
-  background-color: #222;
-  box-shadow: 0 0 0 1px #545454, 0 0 3px rgba(0, 0, 0, 0.08);
+  background-color: var(--main-bg-color);
+  box-shadow: 0 0 0 1px var(--main-highlight), 0 0 3px rgba(0, 0, 0, 0.08);
 }
 
 .popover_menu .arrow::after {
@@ -4918,32 +4927,32 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .popover_menu .content {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .popover_menu {
-  background-color: #222;
-  border-top: 1px solid #545454;
+  background-color: var(--main-bg-color);
+  border-top: 1px solid var(--main-highlight);
 }
 
 .popover_menu.showing_header .arrow::after, .popover_menu.showing_header .arrow_shadow::after {
-  background-color: #222 !important;
+  background-color: var(--main-bg-color) !important;
 }
 
 .post_body .message {
-  background-color: #e6e6e6;
+  background-color: var(--main-text);
 }
 
 .post_body code, .post_body pre {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 .post_body ul.checklist {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .post_body ul.checklist li::before {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 .post_body ul.checklist li.checked {
@@ -4951,7 +4960,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .post_body ul.list.checklist li {
-  border-bottom: 1px solid #545454;
+  border-bottom: 1px solid var(--main-highlight);
 }
 
 .post_body ul.list.checklist li.checked {
@@ -4975,39 +4984,39 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .profile_field_preview_protector .profile_field_preview {
-  background: #222;
-  border: 1px solid #545454;
+  background: var(--main-bg-color);
+  border: 1px solid var(--main-highlight);
 }
 
 .profile_field_preview_protector .profile_field_preview input:disabled, .profile_field_preview_protector .profile_field_preview select:disabled {
-  background: #545454;
+  background: var(--main-highlight);
   color: #949494;
 }
 
 .profile_field_preview_protector .profile_field_preview::after {
-  background-color: #222;
+  background-color: var(--main-bg-color);
   box-shadow: 0 0.75rem 0.75rem rgba(0, 0, 0, 0.25);
 }
 
 .profile_field_preview_protector .profile_field_preview::before {
-  background-color: #222;
+  background-color: var(--main-bg-color);
   box-shadow: 0 0.75rem 0.75rem rgba(0, 0, 0, 0.25);
 }
 
 .ql-container.texty_single_line_input {
-  background: #545454;
-  border: 1px solid #363636;
-  color: #e6e6e6;
+  background: var(--main-highlight);
+  border: 1px solid var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .ql-container.texty_single_line_input.focus, .ql-container.texty_single_line_input:hover {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
   box-shadow: 0 0 7px rgba(0, 0, 0, 0.15);
 }
 
 .ql-editor::-webkit-scrollbar-thumb {
   background-color: rgba(84, 84, 84, 0.5);
-  color: #222;
+  color: var(--main-bg-color);
 }
 
 .ql-editor::-webkit-scrollbar-thumb:hover {
@@ -5015,16 +5024,16 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ql-placeholder, .texty_legacy .ql-placeholder {
-  color: #e6e6e6;
+  color: var(--main-text);
   filter: none;
 }
 
 .quote_block {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .quote_block::before {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 .reply_input_container .inline_message_input_container .ql-container .ql-editor::-webkit-scrollbar-thumb {
@@ -5036,8 +5045,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .reply_input_container .inline_message_input_container .ql-container {
-  background-color: #545454;
-  border: 1px solid #363636;
+  background-color: var(--main-highlight);
+  border: 1px solid var(--main-dark-highlight);
 }
 
 .reply_input_container .inline_message_input_container .ql-container~.emo_menu {
@@ -5049,11 +5058,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .reply_input_container .inline_message_input_container .ql-container.focus~.emo_menu {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .right_border {
-  border-right: 1px solid #363636;
+  border-right: 1px solid var(--main-dark-highlight);
 }
 
 .rxn .emoji_rxn_count, .rxn .c-reaction__count, .c-reaction .emoji_rxn_count, .c-reaction .c-reaction__count, .c-reaction_add .emoji_rxn_count, .c-reaction_add .c-reaction__count, .c-member_slug .emoji_rxn_count, .c-member_slug .c-reaction__count {
@@ -5061,12 +5070,12 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .rxn, .c-reaction, .c-reaction_add, .c-member_slug {
-  background: #363636;
-  border: 0px solid #545454;
+  background: var(--main-dark-highlight);
+  border: 0px solid var(--main-highlight);
 }
 
 .rxn.active .emoji_rxn_count, .rxn:hover .emoji_rxn_count, .c-reaction.active .emoji_rxn_count, .c-reaction:hover .emoji_rxn_count, .c-reaction_add.active .emoji_rxn_count, .c-reaction_add:hover .emoji_rxn_count, .c-member_slug.active .emoji_rxn_count, .c-member_slug:hover .emoji_rxn_count {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .rxn.active, .rxn:hover, .c-reaction.active, .c-reaction:hover, .c-reaction_add.active, .c-reaction_add:hover, .c-member_slug.active, .c-member_slug:hover {
@@ -5074,7 +5083,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .rxn.c-reaction--reacted .emoji_rxn_count, .rxn.c-reaction--reacted .c-reaction__count, .c-reaction.c-reaction--reacted .emoji_rxn_count, .c-reaction.c-reaction--reacted .c-reaction__count, .c-reaction_add.c-reaction--reacted .emoji_rxn_count, .c-reaction_add.c-reaction--reacted .c-reaction__count, .c-member_slug.c-reaction--reacted .emoji_rxn_count, .c-member_slug.c-reaction--reacted .c-reaction__count {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .rxn.c-reaction--reacted, .c-reaction.c-reaction--reacted, .c-reaction_add.c-reaction--reacted, .c-member_slug.c-reaction--reacted {
@@ -5103,7 +5112,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .search_form {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .search_form:hover {
@@ -5111,7 +5120,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .search_input_container .search_input:focus~.icon_search_input {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .search_input.apps_search_input {
@@ -5119,7 +5128,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .search_light_grey {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .search_message_result .search_message_result_meta .date_links a {
@@ -5135,9 +5144,9 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .search_message_result {
-  background: #222 !important;
-  border-color: #363636 !important;
-  color: #e6e6e6 !important;
+  background: var(--main-bg-color) !important;
+  border-color: var(--main-dark-highlight) !important;
+  color: var(--main-text) !important;
 }
 
 .search_message_result_text .result_msg_format a {
@@ -5145,34 +5154,34 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .search_module_footer .top_results_feedback a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .search_module_footer {
-  background-color: #363636;
-  border-bottom-color: #545454;
-  border-left-color: #545454;
-  border-right-color: #545454;
+  background-color: var(--main-dark-highlight);
+  border-bottom-color: var(--main-highlight);
+  border-left-color: var(--main-highlight);
+  border-right-color: var(--main-highlight);
 }
 
 .search_module_footer #see_more {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .search_module_footer #see_more a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .search_module_footer p {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .search_module_footer ts-icon {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .search_module_header {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .search_paging a {
@@ -5180,7 +5189,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .search_paging a:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .search_paging i.disabled {
@@ -5192,13 +5201,13 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .search_result_with_extract {
-  background: #363636;
-  border-color: #545454;
+  background: var(--main-dark-highlight);
+  border-color: var(--main-highlight);
   box-shadow: 0 1px 10px rgba(0, 0, 0, 0.15);
 }
 
 .search_result_with_extract:hover .extract_expand_text, .search_result_with_extract:hover .extract_expand_icons {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .search_result_with_extract:hover {
@@ -5206,34 +5215,34 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .search_segmented_control {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
   color: #949494 !important;
 }
 
 .search_segmented_control:hover {
-  color: #c7c7c7 !important;
+  color: var(--text-hover) !important;
 }
 
 .search_segmented_control.active {
   background: #000;
-  color: #c7c7c7 !important;
+  color: var(--text-hover) !important;
 }
 
 .search_sort_prefix {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .section_rollup {
-  border-bottom-color: #222;
+  border-bottom-color: var(--main-bg-color);
 }
 
 .section_rollup:first-of-type {
-  border-top-color: #222;
+  border-top-color: var(--main-bg-color);
 }
 
 .section_rollup:hover:not(.is_active) {
   background: rgba(34, 34, 34, 0.5);
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .selecting_messages ts-message:hover {
@@ -5249,21 +5258,21 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .share_dialog_attachment_container {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .sidebar_menu_list_item {
   border: 0;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .sidebar_menu_list_item:not(.is_active):hover {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .sidebar_menu_list_item.is_active {
   background-color: #000;
-  color: #e6e6e6;
+  color: var(--main-text);
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
 }
 
@@ -5272,11 +5281,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .sky_blue_bg, .clear_blue_bg, .seafoam_green_bg {
-  background-color: #545454 !important;
+  background-color: var(--main-highlight) !important;
 }
 
 .slack_menu_download {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .slack_menu_download ts-icon {
@@ -5288,7 +5297,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .slack_menu_section::before {
-  border-top-color: #222;
+  border-top-color: var(--main-bg-color);
 }
 
 .slackbot_response_fieldset .delete_response {
@@ -5300,8 +5309,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .sli_expert_search {
-  background-color: #222;
-  color: #e6e6e6;
+  background-color: var(--main-bg-color);
+  color: var(--main-text);
 }
 
 .sli_expert_search__arrow {
@@ -5309,7 +5318,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .sli_expert_search__fg_face::before {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .sli_expert_search__partial_terms {
@@ -5317,28 +5326,28 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .sli_expert_search__plus_sign_overlay {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   color: #949494;
 }
 
 .sli_expert_search__result .app_preview_link, .sli_expert_search__result .member_preview_link {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .sli_expert_search__result {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .sli_expert_search_cta {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .sli_expert_search_cta__text {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .sli_expert_search_cta__text:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .sli_expert_search_cta:hover .sli_expert_search__arrow, .sli_expert_search_header:hover .sli_expert_search__arrow {
@@ -5350,11 +5359,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .snippet_preview pre {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .snippet_preview pre, .snippet_body pre {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .snippet_preview, .snippet_body {
@@ -5362,11 +5371,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .special_formatting_quote .quote_bar {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 .splash_container__background {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .splash_container__background--left, .splash_container__background--center, .splash_container__background--right {
@@ -5374,7 +5383,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .splash_interactive__button {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .splash_interactive__button--active {
@@ -5382,8 +5391,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .splash_interactive__window {
-  background-color: #222;
-  border-color: #545454;
+  background-color: var(--main-bg-color);
+  border-color: var(--main-highlight);
 }
 
 .splash_interactive__window_message_content_text--drive {
@@ -5395,11 +5404,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .splash_interactive__window::after {
-  background: linear-gradient(to bottom, rgba(34, 34, 34, 0) 0, #222 100%);
+  background: linear-gradient(to bottom, rgba(34, 34, 34, 0) 0, var(--main-bg-color) 100%);
 }
 
 .splash_interactive__window:hover .splash_interactive__window_headline {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .sssh-atom {
@@ -5435,7 +5444,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .sssh-hr {
-  color: #363636;
+  color: var(--main-dark-highlight);
 }
 
 .sssh-keyword {
@@ -5455,11 +5464,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .sssh-operator {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .sssh-property {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .sssh-qualifier {
@@ -5507,19 +5516,19 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .statuses_container .current_status_cell .current_status_container .current_status_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_cover {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 .statuses_container .current_status_cell .current_status_container .current_status_emoji_picker_cover, .statuses_container .current_status_cell .current_status_container:not(.active).with_status_set .current_status_emoji_picker_cover {
-  border-right: 1px solid #545454;
+  border-right: 1px solid var(--main-highlight);
 }
 
 .suggestion {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .suggestion.active, .suggestion:hover {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 .supports_custom_scrollbar #messages_container::after {
@@ -5529,15 +5538,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 .supports_custom_scrollbar:not(.slim_scrollbar) #app_space_scroller_div,
 .supports_custom_scrollbar:not(.slim_scrollbar) #archive_msgs_scroller_div,
 .supports_custom_scrollbar:not(.slim_scrollbar) #msgs_scroller_div {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .t-no-header .legal-hero.o-hero.v--short {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .tab_actions {
-  background: #363636;
+  background: var(--main-dark-highlight);
   border: 1px solid #000;
   border-color: #000;
 }
@@ -5548,28 +5557,28 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .tab_complete_ui .tab_complete_ui_header {
   background: padding-box #000;
-  border-bottom: 1px solid #363636;
-  color: #e6e6e6;
+  border-bottom: 1px solid var(--main-dark-highlight);
+  color: var(--main-text);
   text-shadow: 0 1px rgba(0, 0, 0, 0.15);
 }
 
 .tab_complete_ui {
-  background: #222;
-  border: 1px solid #363636;
+  background: var(--main-bg-color);
+  border: 1px solid var(--main-dark-highlight);
   box-shadow: 0 1px 15px rgba(0, 0, 0, 0.5);
 }
 
 .tab_complete_ui li.tab_complete_ui_item, .tab_complete_ui li.tab_complete_ui_group {
-  border-bottom: 1px solid #363636;
+  border-bottom: 1px solid var(--main-dark-highlight);
 }
 
 .tab_complete_ui li.tab_complete_ui_item.active span, .tab_complete_ui li.tab_complete_ui_group.active span {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .tab_complete_ui li.tab_complete_ui_item.active, .tab_complete_ui li.tab_complete_ui_group.active {
-  background: #545454;
-  border-bottom-color: #363636;
+  background: var(--main-highlight);
+  border-bottom-color: var(--main-dark-highlight);
   text-shadow: 0 1px rgba(0, 0, 0, 0.15);
 }
 
@@ -5578,16 +5587,16 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .tab_complete_ui ul.type_cmds .cmdname {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .tab_complete_ui ul.type_cmds li.tab_complete_ui_group .group_divider {
   border-bottom: 0;
-  border-top-color: #363636;
+  border-top-color: var(--main-dark-highlight);
 }
 
 .tab_complete_ui ul.type_cmds li.tab_complete_ui_group .group_name {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 .tab_complete_ui ul.type_cmds li.tab_complete_ui_item .cmd-left-td, .tab_complete_ui ul.type_cmds li.tab_complete_ui_item .cmd-right-td {
@@ -5595,11 +5604,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .tab_complete_ui ul.type_emoji li {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .tab_complete_ui ul.type_members .broadcast_info, .tab_complete_ui ul.type_members .realname {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .tab_complete_ui ul.type_members .unify_broadcast .ts_icon_broadcast {
@@ -5607,7 +5616,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .tab_complete_ui ul.type_members .unify_broadcast {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .tab_container .file_list_item .contents .file_comment_link .ts_icon {
@@ -5619,11 +5628,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .tab_container .file_list_item .contents .file_comment_link:focus .ts_icon, .tab_container .file_list_item .contents .file_comment_link:hover .ts_icon {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .tab_container .file_list_item .contents .file_comment_link:focus, .tab_container .file_list_item .contents .file_comment_link:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 .tab_container .file_list_item .contents .member, .tab_container .file_list_item .contents .service_link, .tab_container .file_list_item .contents .share_info, .tab_container .file_list_item .contents .time {
@@ -5639,16 +5648,16 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .tab_container .file_list_item:focus, .tab_container .file_list_item:hover {
-  background-color: #222;
-  border-color: #363636;
+  background-color: var(--main-bg-color);
+  border-color: var(--main-dark-highlight);
 }
 
 .tab_container .star_item .message .actions .btn_icon, .tab_container .star_item .message .actions .star_jump, .tab_container .star_item ts-message .actions .btn_icon, .tab_container .star_item ts-message .actions .star_jump, .tab_container .file_list_item .actions .btn_icon, .tab_container .file_list_item .actions .star_jump, .tab_container .file_comment_item .actions .btn_icon, .tab_container .file_comment_item .actions .star_jump {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .tab_container .star_item .message .actions .btn::after, .tab_container .star_item ts-message .actions .btn::after, .tab_container .file_list_item .actions .btn::after, .tab_container .file_comment_item .actions .btn::after {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 .tab_container .star_item .message .timestamp, .tab_container .star_item ts-message .timestamp {
@@ -5660,7 +5669,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .tab_menu .tab {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .tab_menu .tab:disabled {
@@ -5673,15 +5682,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .tab_menu .tab.active, .tab_menu .tab:active, .tab_menu .tab:focus {
   box-shadow: inset 0 -4px 0 0 #bf360c;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .tab_menu {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .tab_menu.grey {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .tab_set a.secondary {
@@ -5689,36 +5698,36 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .tab_set a.selected, .tab_set a.secondary.selected {
-  background: #363636;
+  background: var(--main-dark-highlight);
   border: 1px solid #000;
-  border-bottom-color: #363636;
-  color: #c7c7c7;
+  border-bottom-color: var(--main-dark-highlight);
+  color: var(--text-hover);
 }
 
 .team_list_item .member_name {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .team_list_item {
-  border-top: 1px solid #545454;
+  border-top: 1px solid var(--main-highlight);
   color: #949494;
 }
 
 .textstyle_menu .arrow-shadow::after {
-  background-color: #363636;
-  box-shadow: 0 0 0 1px #363636;
+  background-color: var(--main-dark-highlight);
+  box-shadow: 0 0 0 1px var(--main-dark-highlight);
 }
 
 .textstyle_menu .arrow::after {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .textstyle_menu .buttons a:hover, .textstyle_menu.style a:hover {
-  border: 1px solid #545454;
+  border: 1px solid var(--main-highlight);
 }
 
 .textstyle_menu .buttons a.active, .textstyle_menu.style a.active {
-  background-color: #545454;
+  background-color: var(--main-highlight);
   border: 1px solid #828282;
 }
 
@@ -5727,16 +5736,16 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .textstyle_menu .content {
-  background-color: #363636;
-  box-shadow: 0 0 0 1px #363636, 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25);
+  background-color: var(--main-dark-highlight);
+  box-shadow: 0 0 0 1px var(--main-dark-highlight), 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25);
 }
 
 .textstyle_menu.link .arrow-shadow::after {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .textstyle_menu.link .arrow::after {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .textstyle_menu.link .content ::-webkit-input-placeholder, .textstyle_menu.link .content ::-moz-placeholder {
@@ -5744,11 +5753,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .textstyle_menu.link .content .buttons a.item.active, .textstyle_menu.link .content .buttons a.item:hover {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .textstyle_menu.link .content {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   box-shadow: 0 0 1px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.25);
 }
 
@@ -5757,22 +5766,22 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .textstyle_menu.link .content input[type=text] {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 .textstyle_menu.style a.deformat::before {
-  border-left: 1px solid #545454;
+  border-left: 1px solid var(--main-highlight);
 }
 
 .toolbar_container {
-  background: #222;
+  background: var(--main-bg-color);
   border-bottom: 1px solid #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .tooltip-inner {
   background-color: #828282;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .tooltip.bottom .tooltip-arrow {
@@ -5792,7 +5801,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .top_border {
-  border-top: 1px solid #363636;
+  border-top: 1px solid var(--main-dark-highlight);
 }
 
 .top_results_search_message_result .channel {
@@ -5804,7 +5813,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .top_results_search_message_result .jump {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .top_results_search_message_result .timestamp {
@@ -5812,31 +5821,31 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .top_results_search_message_result {
-  background-color: #363636;
-  border-bottom-color: #545454;
-  border-left-color: #545454;
-  border-right-color: #545454;
+  background-color: var(--main-dark-highlight);
+  border-bottom-color: var(--main-highlight);
+  border-left-color: var(--main-highlight);
+  border-right-color: var(--main-highlight);
 }
 
 .top_results_search_message_result:first-child {
-  border-top: 2px solid #545454;
+  border-top: 2px solid var(--main-highlight);
 }
 
 .top_results_search_message_result:hover {
   border-color: rgba(130, 130, 130, 0.6) !important;
-  border-top: 2px solid #545454 !important;
+  border-top: 2px solid var(--main-highlight) !important;
 }
 
 .top_results_search_message_result.duplicate {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 .ts_tip .ts_tip_multiline_inner, .ts_tip:not(.ts_tip_multiline) .ts_tip_tip {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 .ts_tip .ts_tip_tip {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .ts_tip.success .ts_tip_tip {
@@ -5860,29 +5869,29 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .ts_tip.ts_tip_bottom .ts_tip_tip::after {
-  border-bottom-color: #545454;
+  border-bottom-color: var(--main-highlight);
 }
 
 .ts_tip.ts_tip_left .ts_tip_tip::after {
-  border-left-color: #545454;
+  border-left-color: var(--main-highlight);
 }
 
 .ts_tip.ts_tip_right .ts_tip_tip::after {
-  border-right-color: #545454;
+  border-right-color: var(--main-highlight);
 }
 
 .ts_tip.ts_tip_top .ts_tip_tip::after {
-  border-top-color: #545454;
+  border-top-color: var(--main-highlight);
 }
 
 .two_factor_choice {
-  background-color: #363636;
-  border: 1px solid #545454;
+  background-color: var(--main-dark-highlight);
+  border: 1px solid var(--main-highlight);
   box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25);
 }
 
 .two_factor_choice:hover .two_factor_link {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .two_factor_choice:hover {
@@ -5896,7 +5905,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 .uneditable-input, .uneditable-textarea {
   background-color: #424242;
   border: 1px solid #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .uneditable-input:focus, .uneditable-textarea:focus {
@@ -5913,12 +5922,12 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .unread_empty_state_undo_action {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .unread_empty_state_undo_inner {
   background: #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .unread_group .unread_group_header .unread_group_collapse_caret .ts_icon_caret_down {
@@ -5926,17 +5935,17 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .unread_group .unread_group_header .unread_group_collapse_toggle:hover ts-icon {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .unread_group .unread_group_header .unread_group_mark, .unread_group .unread_group_header .unread_keyboard {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .unread_group .unread_group_header {
-  background: #363636;
-  border-top-color: #545454;
-  color: #e6e6e6;
+  background: var(--main-dark-highlight);
+  border-top-color: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .unread_group_footer .unread_group_new .unread_group_new_text {
@@ -5948,21 +5957,21 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .unread_group_header_name a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .unread_group.active .unread_group_header {
   background: #000;
-  border-top-color: #545454;
-  color: #e6e6e6;
+  border-top-color: var(--main-highlight);
+  color: var(--main-text);
 }
 
 .unread_group.marked_as_read .unread_group_header {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .unread_msgs_loading {
-  background: #222;
+  background: var(--main-bg-color);
   background-image: none;
 }
 
@@ -5983,7 +5992,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .user_group_item {
-  border-bottom: 1px solid #545454;
+  border-bottom: 1px solid var(--main-highlight);
 }
 
 .user_group_item a {
@@ -5993,7 +6002,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 .well {
   background: #000;
   border-color: black;
-  color: #e6e6e6;
+  color: var(--main-text);
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
 }
 
@@ -6006,7 +6015,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .widescreen:not(.nav_open) {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .widescreen:not(.nav_open) nav#site_nav #user_menu_name {
@@ -6014,7 +6023,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .widescreen:not(.nav_open) nav#site_nav h3 {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 .widescreen:not(.nav_open) nav#site_nav ul a {
@@ -6030,16 +6039,16 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 [data-placeholder]:empty::before {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 @keyframes border_focus_animation {
   0% {
-    box-shadow: 0 0 4px 0.25px #545454, 0 0 0 0.5px #828282;
+    box-shadow: 0 0 4px 0.25px var(--main-highlight), 0 0 0 0.5px #828282;
   }
 
   100% {
-    box-shadow: 0 0 4px 0 #545454, 0 0 0 0 #828282;
+    box-shadow: 0 0 4px 0 var(--main-highlight), 0 0 0 0 #828282;
   }
 }
 
@@ -6049,13 +6058,13 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
   }
 
   to {
-    color: #e6e6e6;
+    color: var(--main-text);
   }
 }
 
 @keyframes fade-background-highlight {
   0% {
-    background: #545454;
+    background: var(--main-highlight);
   }
 
   100% {
@@ -6087,13 +6096,13 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 @media screen and (min-width: 48rem) {
   .help_pages.help_pages .o-hero {
-    background-color: #222;
+    background-color: var(--main-bg-color);
   }
 }
 
 @media screen and (min-width: 67.8125rem) {
   .legal-main .c-nav--sidebar__listheader {
-    color: #e6e6e6;
+    color: var(--main-text);
   }
 
   .legal-main .c-nav--sidebar__listitem a.is-selected {
@@ -6103,26 +6112,26 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 @media screen and (min-width: 67.8125rem) {
   .t-no-header .legal-main {
-    background-color: #363636;
+    background-color: var(--main-dark-highlight);
   }
 }
 
 #admin_invites_add_row {
-  background: #545454;
-  border: 1px solid #363636;
+  background: var(--main-highlight);
+  border: 1px solid var(--main-dark-highlight);
 }
 
 #admin_invites_alert {
-  background: #545454;
+  background: var(--main-highlight);
   border-color: #828282;
 }
 
 #admin_invites_channel_picker_container {
-  border-bottom: 1px solid #363636;
+  border-bottom: 1px solid var(--main-dark-highlight);
 }
 
 #admin_invites_workflow .lazy_filter_select .lfs_input_container {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 #api_nav .footer_nav .footer_signature {
@@ -6134,11 +6143,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #api_nav .footer_nav a:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 #archives_end_div_msg_lim h1, #end_display_msg_lim h1 {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #archives_end_div_msg_lim h2, #end_display_msg_lim h2 {
@@ -6147,11 +6156,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 #archives_return {
   background: padding-box #828282;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #archives_return a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #archives_return a:hover {
@@ -6163,20 +6172,20 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #at_channel_warning_dialog {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 #at_channel_warning_dialog.fullsize .modal-body {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 #at_channel_warning_dialog.fullsize {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 #autocomplete_menu .boxed {
-  background: #222;
-  border: 1px solid #363636;
+  background: var(--main-bg-color);
+  border: 1px solid var(--main-dark-highlight);
   box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.15);
 }
 
@@ -6185,19 +6194,19 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #autocomplete_menu .no_results {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #autocomplete_menu .pickmeup {
-  border-bottom: 1px solid #363636;
+  border-bottom: 1px solid var(--main-dark-highlight);
 }
 
 #autocomplete_menu {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #autocomplete_menu h2 {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #autocomplete_menu header .header_label {
@@ -6205,7 +6214,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #autocomplete_menu header {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 #autocomplete_menu header hr {
@@ -6222,7 +6231,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #autocomplete_menu.search_menu .query_header .search_query_preview, #autocomplete_menu.search_menu.unified .query_header .search_query_preview {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #autocomplete_menu.search_menu .query_header, #autocomplete_menu.search_menu.unified .query_header {
@@ -6230,34 +6239,34 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #autocomplete_menu.search_menu .result_item_btn, #autocomplete_menu.search_menu.unified .result_item_btn {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #autocomplete_menu.search_menu .results.unified .unified_autocomplete_item .text, #autocomplete_menu.search_menu.unified .results.unified .unified_autocomplete_item .text {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #autocomplete_menu.search_menu .results.unified .unified_autocomplete_item .token, #autocomplete_menu.search_menu.unified .results.unified .unified_autocomplete_item .token {
   background-color: #424242;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #autocomplete_menu.search_menu .section_header::before, #autocomplete_menu.search_menu.unified .section_header::before {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 #autocomplete_menu.search_menu .time_modifiers::before, #autocomplete_menu.search_menu.unified .time_modifiers::before {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 #autocomplete_menu.search_menu footer .keyword::before, #autocomplete_menu.search_menu footer .modifier::before, #autocomplete_menu.search_menu footer.unified .keyword::before, #autocomplete_menu.search_menu footer.unified .modifier::before, #autocomplete_menu.search_menu.unified footer .keyword::before, #autocomplete_menu.search_menu.unified footer .modifier::before, #autocomplete_menu.search_menu.unified footer.unified .keyword::before, #autocomplete_menu.search_menu.unified footer.unified .modifier::before {
   background: #828282;
-  border: 1px solid #545454;
-  color: #e6e6e6;
+  border: 1px solid var(--main-highlight);
+  color: var(--main-text);
 }
 
 #autocomplete_menu.search_menu footer .modifier.incomplete::before, #autocomplete_menu.search_menu footer.unified .modifier.incomplete::before, #autocomplete_menu.search_menu.unified footer .modifier.incomplete::before, #autocomplete_menu.search_menu.unified footer.unified .modifier.incomplete::before {
-  background: #363636;
+  background: var(--main-dark-highlight);
   border: 1px solid #000;
 }
 
@@ -6267,15 +6276,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #autocomplete_menu.search_menu header .header_label::before, #autocomplete_menu.search_menu.unified header .header_label::before {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 #autocomplete_menu.search_menu header, #autocomplete_menu.search_menu.unified header {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #autocomplete_menu.search_menu li.highlighted .action_btn, #autocomplete_menu.search_menu.unified li.highlighted .action_btn {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #autocomplete_menu.search_menu li.highlighted .delete_btn, #autocomplete_menu.search_menu.unified li.highlighted .delete_btn {
@@ -6295,13 +6304,13 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #autocomplete_menu.search_menu li.highlighted .result_item_btn, #autocomplete_menu.search_menu.unified li.highlighted .result_item_btn {
-  background: #363636;
-  color: #e6e6e6;
+  background: var(--main-dark-highlight);
+  color: var(--main-text);
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
 }
 
 #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .action_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .action_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .action_btn {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .delete_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .delete_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .delete_btn {
@@ -6321,8 +6330,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #autocomplete_menu.search_menu:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu .results.unified:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu.unified:not(.keyboard_active) li:hover .result_item_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:focus .result_item_btn, #autocomplete_menu.search_menu.unified .results.unified:not(.keyboard_active) li:hover .result_item_btn {
-  background: #363636;
-  color: #e6e6e6;
+  background: var(--main-dark-highlight);
+  color: var(--main-text);
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
 }
 
@@ -6331,22 +6340,22 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #billing_contacts_container {
-  background: #363636;
+  background: var(--main-dark-highlight);
   border-top: 1px solid #000;
 }
 
 #canvases_toggle.active, #details_toggle.active, #recent_mentions_toggle.active, #sli_recap_toggle.active, #stars_toggle.active {
-  background: #363636;
-  color: #e6e6e6;
+  background: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 #canvases_toggle.active:hover, #details_toggle.active:hover, #recent_mentions_toggle.active:hover, #sli_recap_toggle.active:hover, #stars_toggle.active:hover {
-  background: #545454;
-  color: #e6e6e6;
+  background: var(--main-highlight);
+  color: var(--main-text);
 }
 
 #channel_browser .channel_browser_channel_purpose {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #channel_browser .channel_browser_creator_name {
@@ -6363,33 +6372,33 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #channel_browser .channel_browser_row {
-  border-top: 1px solid #363636;
-  color: #e6e6e6;
+  border-top: 1px solid var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 #channel_browser .channel_browser_row_header {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #channel_browser .channel_browser_sort_container::after {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #channel_browser #channel_list_container:not(.keyboard_active).not_scrolling .channel_browser_row:hover, #channel_browser .channel_browser_row.highlighted {
   background: #000;
-  border: 1px solid #545454;
+  border: 1px solid var(--main-highlight);
 }
 
 #channel_invite_container .lfs_list_container .lfs_item {
-  border-top-color: #363636;
+  border-top-color: var(--main-dark-highlight);
 }
 
 #channel_invite_container .lfs_list_container .lfs_item.active {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 #channel_invite_container.page_needs_enterprise .channel_invite_row {
-  border-top-color: #363636;
+  border-top-color: var(--main-dark-highlight);
 }
 
 #channel_invite_container.page_needs_enterprise .channel_invite_row.disabled {
@@ -6397,13 +6406,13 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #channel_invite_modal #channel_invite_container:not(.keyboard_active).not_scrolling .channel_invite_row:not(.disabled):hover, #channel_invite_modal .channel_invite_row.highlighted:not(.disabled) {
-  background: #222;
-  border-color: #363636;
+  background: var(--main-bg-color);
+  border-color: var(--main-dark-highlight);
 }
 
 #channel_invite_tokens .member_token {
-  background: #222;
-  color: #e6e6e6;
+  background: var(--main-bg-color);
+  color: var(--main-text);
 }
 
 #channel_invite_tokens .member_token.ra {
@@ -6411,7 +6420,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #channel_invite_tokens {
-  background-color: #545454;
+  background-color: var(--main-highlight);
   border-color: #828282;
 }
 
@@ -6431,15 +6440,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #channel_prefs_dialog {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #channel_specific_settings .extra_left_border {
-  border-left-color: #222;
+  border-left-color: var(--main-bg-color);
 }
 
 #channel_specific_settings .extra_right_border {
-  border-right-color: #222;
+  border-right-color: var(--main-bg-color);
 }
 
 #channel_specific_settings .revert_to_default {
@@ -6451,7 +6460,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #channel_specific_settings tr {
-  border-top-color: #222;
+  border-top-color: var(--main-bg-color);
 }
 
 #channel_specific_settings tr.channel_override_row.muted td {
@@ -6459,19 +6468,19 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #client_body:not(.onboarding)::before {
-  background: #222;
-  border-bottom: 1px solid #363636;
-  box-shadow: inset 1px 0 0 0 #222;
+  background: var(--main-bg-color);
+  border-bottom: 1px solid var(--main-dark-highlight);
+  box-shadow: inset 1px 0 0 0 var(--main-bg-color);
 }
 
 #client_body:not(.onboarding):not(.feature_global_nav_layout)::before {
-  background: #222;
-  border-bottom: 1px solid #363636;
-  box-shadow: inset 1px 0 0 0 #222;
+  background: var(--main-bg-color);
+  border-bottom: 1px solid var(--main-dark-highlight);
+  box-shadow: inset 1px 0 0 0 var(--main-bg-color);
 }
 
 #client_body:not(.onboarding):not(.feature_global_nav_layout):before {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 #client-ui .file_list_item.file_list_item--redesign .file_list_item__channel {
@@ -6483,19 +6492,19 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #client-ui .file_list_item.file_list_item--redesign {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 #client-ui .member_file_filter_menu .searchable_member_list_scroller .team_list_item:hover .channel_page_member_row {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 #client-ui .member_file_filter_menu .searchable_member_list_scroller .team_list_item:hover .member {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #client-ui .member_filter {
-  border: 1px solid #545454;
+  border: 1px solid var(--main-highlight);
 }
 
 #client-ui .monkey_scroll_bar {
@@ -6503,8 +6512,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #client-ui .monkey_scroll_handle_inner {
-  background: #545454;
-  border: 3px solid #222;
+  background: var(--main-highlight);
+  border: 3px solid var(--main-bg-color);
 }
 
 #client-ui .searchable_member_list .team_list_item {
@@ -6512,19 +6521,19 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #client-ui .searchable_member_list .team_list_item a, #client-ui #team_list .team_list_item a, #member_preview_scroller .team_list_item a {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 #client-ui .searchable_member_list .team_list_item:hover {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 #client-ui .searchable_member_list .team_list_item:hover, #client-ui #team_list .team_list_item:hover, #member_preview_scroller .team_list_item:hover {
-  border-color: #545454 !important;
+  border-color: var(--main-highlight) !important;
 }
 
 #client-ui .searchable_member_list .team_list_item.expanded, #client-ui #team_list .team_list_item.expanded, #member_preview_scroller .team_list_item.expanded {
-  border-color: #363636 !important;
+  border-color: var(--main-dark-highlight) !important;
 }
 
 #client-ui .team_tabs_container {
@@ -6532,20 +6541,20 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #client-ui #file_member_filter .member_filter {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 #client-ui #file_member_filter {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 #client-ui #team_list_container #team_filter .member_filter {
-  background-color: #222;
+  background-color: var(--main-bg-color);
   border-left: 1px solid #000;
 }
 
 #client-ui.flex_pane_showing #col_flex {
-  border-left-color: #363636;
+  border-left-color: var(--main-dark-highlight);
 }
 
 #coachmark_footer .coachmark_done, #coachmark_footer .coachmark_got_it, #coachmark_footer .coachmark_next_tip, #coachmark_footer .coachmark_ok {
@@ -6553,23 +6562,23 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #coachmark_interior .coachmark_close_btn {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #coachmark_interior {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_callout, #coachmark.calls_interactive_mas_migration_coachmark_div #coachmark_interior, #coachmark.calls_iss_window_coachmark_div #coachmark_callout, #coachmark.calls_iss_window_coachmark_div #coachmark_interior, #coachmark.calls_ss_main_coachmark_div #coachmark_callout, #coachmark.calls_ss_main_coachmark_div #coachmark_interior, #coachmark.calls_ss_window_coachmark_div #coachmark_callout, #coachmark.calls_ss_window_coachmark_div #coachmark_interior, #coachmark.calls_video_beta_coachmark_div #coachmark_callout, #coachmark.calls_video_beta_coachmark_div #coachmark_interior, #coachmark.calls_video_ga_coachmark_div #coachmark_callout, #coachmark.calls_video_ga_coachmark_div #coachmark_interior, #coachmark.channels_coachmark_div #coachmark_callout, #coachmark.channels_coachmark_div #coachmark_interior, #coachmark.direct_messages_coachmark_div #coachmark_callout, #coachmark.direct_messages_coachmark_div #coachmark_interior, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_callout, #coachmark.enterprise_analytics_usage_callouts_coachmark_div #coachmark_interior, #coachmark.gdrive_coachmark_div #coachmark_callout, #coachmark.gdrive_coachmark_div #coachmark_interior, #coachmark.highlights_arrows_coachmark_div #coachmark_callout, #coachmark.highlights_arrows_coachmark_div #coachmark_interior, #coachmark.highlights_feedback_coachmark_div #coachmark_callout, #coachmark.highlights_feedback_coachmark_div #coachmark_interior, #coachmark.highlights_message_coachmark_div #coachmark_callout, #coachmark.highlights_message_coachmark_div #coachmark_interior, #coachmark.intl_channel_names_coachmark_div #coachmark_callout, #coachmark.intl_channel_names_coachmark_div #coachmark_interior, #coachmark.invites_coachmark_div #coachmark_callout, #coachmark.invites_coachmark_div #coachmark_interior, #coachmark.name_tagging_coachmark_div #coachmark_callout, #coachmark.name_tagging_coachmark_div #coachmark_interior, #coachmark.onboarding_coachmark_div #coachmark_callout, #coachmark.onboarding_coachmark_div #coachmark_interior, #coachmark.recent_mentions_coachmark_div #coachmark_callout, #coachmark.recent_mentions_coachmark_div #coachmark_interior, #coachmark.replies_coachmark_div #coachmark_callout, #coachmark.replies_coachmark_div #coachmark_interior, #coachmark.screenhero_deprecation_coachmark_div #coachmark_callout, #coachmark.screenhero_deprecation_coachmark_div #coachmark_interior, #coachmark.starred_items_coachmark_div #coachmark_callout, #coachmark.starred_items_coachmark_div #coachmark_interior, #coachmark.unread_view_coachmark_div #coachmark_callout, #coachmark.unread_view_coachmark_div #coachmark_interior {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 #coachmark.calls_interactive_mas_migration_coachmark_div, #coachmark.calls_iss_window_coachmark_div, #coachmark.calls_ss_main_coachmark_div, #coachmark.calls_ss_window_coachmark_div, #coachmark.calls_video_beta_coachmark_div, #coachmark.calls_video_ga_coachmark_div, #coachmark.channels_coachmark_div, #coachmark.direct_messages_coachmark_div, #coachmark.enterprise_analytics_usage_callouts_coachmark_div, #coachmark.gdrive_coachmark_div, #coachmark.highlights_arrows_coachmark_div, #coachmark.highlights_feedback_coachmark_div, #coachmark.highlights_message_coachmark_div, #coachmark.intl_channel_names_coachmark_div, #coachmark.invites_coachmark_div, #coachmark.name_tagging_coachmark_div, #coachmark.onboarding_coachmark_div, #coachmark.recent_mentions_coachmark_div, #coachmark.replies_coachmark_div, #coachmark.screenhero_deprecation_coachmark_div, #coachmark.starred_items_coachmark_div, #coachmark.unread_view_coachmark_div {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 #col_channels {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #col_flex {
@@ -6577,34 +6586,34 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #col_messages {
-  box-shadow: inset 1px 0 0 0 #222;
+  box-shadow: inset 1px 0 0 0 var(--main-bg-color);
 }
 
 #connected_members .connected_members_count {
-  color: #e6e6e6;
+  color: var(--main-text);
   text-shadow: -1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000, 1px -1px 0 #000;
 }
 
 #connected_members .toggle_more_members_popover {
-  background: #222;
+  background: var(--main-bg-color);
   color: #949494;
 }
 
 #connected_members_overflow_popover .arrow_shadow::after {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5), 0 0 2px rgba(0, 0, 0, 0.5);
 }
 
 #connected_members_overflow_popover .arrow::after {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 #connected_members_overflow_popover .monkey_scroll_wrapper {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 #connected_members_overflow_popover {
-  border-bottom: 1px solid #363636;
+  border-bottom: 1px solid var(--main-dark-highlight);
   border-left: 1px solid rgba(0, 0, 0, 0.11);
   border-right: 1px solid rgba(0, 0, 0, 0.11);
   border-top: 1px solid rgba(0, 0, 0, 0.11);
@@ -6616,26 +6625,26 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #connection_status #connection_label {
-  color: #e6e6e6;
+  color: var(--main-text);
   text-shadow: -1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000, 1px -1px 0 #000;
 }
 
 #convo_container .convo_flexpane_divider .reply_count {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 #convo_container .convo_flexpane_divider {
-  border-top-color: #363636;
+  border-top-color: var(--main-dark-highlight);
   color: #949494;
 }
 
 #convo_container {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 #convo_container #message_edit_container {
-  border-bottom: 1px solid #545454;
-  border-top: 1px solid #545454;
+  border-bottom: 1px solid var(--main-highlight);
+  border-top: 1px solid var(--main-highlight);
 }
 
 #convo_container ts-conversation ts-message.selected .message_content .thread_channel_link {
@@ -6643,11 +6652,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #convo_container ts-conversation ts-message.selected {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 #convo_container ts-conversation ts-relatives ts-message:not(.selected):not(.highlight):not(.delete_mode) {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 #convo_container ts-conversation ts-relatives ts-message:not(.selected):not(.highlight):not(.delete_mode).new {
@@ -6655,16 +6664,16 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #convo_container ts-conversation ts-relatives ts-message.deleted .message_content {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #convo_container ts-conversation ts-relatives ts-message.deleted .message_icon i {
-  background-color: #545454;
+  background-color: var(--main-highlight);
   color: #949494;
 }
 
 #convo_container ts-conversation ts-relatives::after {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 #convo_container ts-conversation::after {
@@ -6684,7 +6693,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #convo_tab .message_input, #convo_tab textarea#msg_text {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #convo_tab .thread_participants, ts-thread .thread_participants {
@@ -6692,11 +6701,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #convo_tab #convo_tab_btns .close_flexpane:focus, #convo_tab #convo_tab_btns .close_flexpane:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #convo_tab textarea.message_input {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #details_tab .channel_page_action .leave_link {
@@ -6704,7 +6713,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #details_tab .channel_page_action .leave_link:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 #details_tab .channel_page_member_tabs .icon_member_header {
@@ -6724,16 +6733,16 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #details_tab .channel_page_section .section_header:hover .disclosure_triangle {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 #details_tab .channel_page_section .section_title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #details_tab .channel_page_section {
-  background: #222;
-  border-top: 1px solid #363636;
+  background: var(--main-bg-color);
+  border-top: 1px solid var(--main-dark-highlight);
 }
 
 #details_tab .channel_section_label .ts_icon_info_circle {
@@ -6741,7 +6750,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #details_tab .conversation_details .member_info_timezone {
-  border-top-color: #545454;
+  border-top-color: var(--main-highlight);
 }
 
 #details_tab .conversation_details .member_name:hover {
@@ -6749,11 +6758,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #details_tab .conversation_details .member_username:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #details_tab .created_by {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #details_tab .feature_sli_channel_insights .channel_created_section .creator_link, #details_tab .feature_sli_channel_insights .channel_purpose_section .channel_purpose_text {
@@ -6769,15 +6778,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #details_tab .heading a.close_flexpane:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 #details_tab .pinned_item:hover {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 #details_tab hr {
-  border-top-color: #363636;
+  border-top-color: var(--main-dark-highlight);
 }
 
 #disabled_members_tab a {
@@ -6786,7 +6795,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 #disabled_members_tab a:hover {
   background: #424242;
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 #disabled_members_tab.active a {
@@ -6794,25 +6803,25 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #edit_team_profile_add .row, #edit_team_profile_list .row {
-  border-top: 1px solid #363636;
+  border-top: 1px solid var(--main-dark-highlight);
 }
 
 #edit_team_profile_add .row:last-child {
-  border-bottom: 1px solid #545454;
+  border-bottom: 1px solid var(--main-highlight);
 }
 
 #edit_team_profile_add .row:not(.header_row):hover .col:first-child {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #edit_team_profile_add .row:not(.header_row):hover {
-  background: #363636;
+  background: var(--main-dark-highlight);
   border: 1px solid #000;
 }
 
 #edit_team_profile_add .row:not(.header_row):hover i {
   border-color: #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #edit_team_profile_add i {
@@ -6820,20 +6829,20 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #edit_team_profile_container .lazy_filter_select.disabled {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 #edit_team_profile_container .lazy_filter_select.disabled input {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 #edit_team_profile_container input:disabled, #edit_team_profile_container select:disabled {
-  background: #545454;
+  background: var(--main-highlight);
   border: 1px solid #000;
 }
 
 #edit_team_profile_custom .row .col .profile_field_preview {
-  background: #363636;
+  background: var(--main-dark-highlight);
   border: 2px solid #000;
 }
 
@@ -6842,11 +6851,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #edit_team_profile_custom .row .col .profile_field_preview:active, #edit_team_profile_custom .row .col .profile_field_preview:hover {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 #edit_team_profile_custom .row .col input {
-  background: #545454;
+  background: var(--main-highlight);
   border: 1px solid #000;
 }
 
@@ -6864,7 +6873,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 #edit_team_profile_edit .row i {
   border: 1px solid #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #edit_team_profile_edit .row.option_row.show_remove_action i {
@@ -6874,11 +6883,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 #edit_team_profile_edit .row.option_row.show_remove_action i:hover {
   background-color: #bf360c;
   border-color: #bf360c !important;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #edit_team_profile_list .edit_team_profile_list_controls i {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #edit_team_profile_list .edit_team_profile_list_controls i.ts_icon_cog_o:hover {
@@ -6894,21 +6903,21 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #edit_team_profile_list .row:nth-child(n+5).active, #edit_team_profile_list .row:nth-child(n+5):hover {
-  background: #363636;
+  background: var(--main-dark-highlight);
   border: 1px solid #000;
 }
 
 #edit_team_profile_list .row:nth-last-child(2):hover {
-  border-color: #363636 !important;
+  border-color: var(--main-dark-highlight) !important;
 }
 
 #edit_team_profile_list .sortable-placeholder::before {
-  border-top: 1px solid #545454;
+  border-top: 1px solid var(--main-highlight);
 }
 
 #edit_topic_inner:not(.unable_to_post)::before {
-  background: #222;
-  border-color: #363636;
+  background: var(--main-bg-color);
+  border-color: var(--main-dark-highlight);
 }
 
 #edit_topic_trigger {
@@ -6916,13 +6925,13 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #file_comment_textarea.texty_comment_input {
-  background: #222;
-  border-color: #363636;
-  color: #e6e6e6;
+  background: var(--main-bg-color);
+  border-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 #file_comment_textarea.texty_comment_input.focus, #file_comment_textarea.texty_comment_input:hover {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 #file_list_toggle_users {
@@ -6934,7 +6943,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #file_list_toggle_users.active:hover, #file_list_toggle_users:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 #file_member_filter {
@@ -6942,12 +6951,12 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #file_page_preview img {
-  background: #222;
+  background: var(--main-bg-color);
   border: 1px solid #000;
 }
 
 #file_page_preview img:hover {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 #file_preview_container .file_meta {
@@ -6963,7 +6972,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #flex_contents .flexpane_tab_bar li:hover {
-  border-bottom: 4px solid #363636;
+  border-bottom: 4px solid var(--main-dark-highlight);
 }
 
 #flex_contents .flexpane_tab_bar li:hover a, #flex_contents .flexpane_tab_bar li:hover .tab {
@@ -6971,7 +6980,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #flex_contents .flexpane_tab_bar li.active {
-  border-bottom: 4px solid #363636;
+  border-bottom: 4px solid var(--main-dark-highlight);
 }
 
 #flex_contents .flexpane_tab_bar li.active a, #flex_contents .flexpane_tab_bar li.active .tab {
@@ -6979,11 +6988,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #flex_contents .flexpane_tab_toolbar #user_group_edit {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 #flex_contents .flexpane_tab_toolbar #user_group_edit.user_group_edit--flexpane .tab_action_button {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #flex_contents .heading .cancel_link {
@@ -6991,7 +7000,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #flex_contents .heading .menu_heading:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #flex_contents .heading .menu_icon {
@@ -6999,12 +7008,12 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #flex_contents .heading .menu_icon:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 #flex_contents .heading {
   background: #151515;
-  border-bottom-color: #363636;
+  border-bottom-color: var(--main-dark-highlight);
   color: #949494;
 }
 
@@ -7013,7 +7022,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #flex_contents .heading a:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 #flex_contents .heading a.close_flexpane {
@@ -7026,7 +7035,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 #flex_contents .help {
   border-top: 5px solid #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #flex_contents .subheading:not(.empty) .filter_menu_label.active .arrow_down {
@@ -7034,35 +7043,35 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #flex_contents .subheading:not(.empty) {
-  background: #222;
+  background: var(--main-bg-color);
   border-top: 1px solid #000;
   color: #949494;
 }
 
 #flex_contents .subheading:not(.empty) p a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #flex_contents .subheading:not(.empty)#mentions_options {
-  background-color: #222;
-  border-bottom-color: #363636;
-  color: #e6e6e6;
+  background-color: var(--main-bg-color);
+  border-bottom-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 #flex_contents .toolbar_container {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 #flex_contents .user_group_item:hover {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 #flex_contents .user_group_item:hover h4 {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #flex_contents {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 #flex_contents i.callout {
@@ -7070,20 +7079,20 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #flex_menu_toggle .flex_menu_download_circle {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 #flex_menu_toggle .flex_menu_download_circle canvas {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 #flex_menu_toggle.active, #flex_menu_toggle.active:focus {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #flex_menu_toggle.open #help_icon_circle_count {
   background-color: #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #flex_menu_toggle.unread #help_icon_circle_count {
@@ -7092,8 +7101,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #footer_archives_preview {
-  background-color: #222;
-  border-top: 1px solid #363636;
+  background-color: var(--main-bg-color);
+  border-top: 1px solid var(--main-dark-highlight);
 }
 
 #footer_archives_table {
@@ -7101,13 +7110,13 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #footer, #footer.footer_msg_input {
-  background: #222;
-  box-shadow: inset 1px 0 0 0 #222;
+  background: var(--main-bg-color);
+  box-shadow: inset 1px 0 0 0 var(--main-bg-color);
 }
 
 #footer.disabled #message-input, #footer.disabled #msg_input {
-  background: padding-box #363636 !important;
-  border-color: #363636 !important;
+  background: padding-box var(--main-dark-highlight) !important;
+  border-color: var(--main-dark-highlight) !important;
 }
 
 #fs_modal .fs_modal_btn {
@@ -7116,59 +7125,59 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 #fs_modal .fs_modal_btn:active {
   background: #828282;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #fs_modal .fs_modal_btn:hover {
   background: #828282;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #fs_modal {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 #fs_modal #fs_modal_footer {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 #fs_modal #fs_modal_sidebar a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #fs_modal #fs_modal_sidebar a:hover {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 #fs_modal #fs_modal_sidebar a.active {
   background: #000;
-  color: #e6e6e6;
+  color: var(--main-text);
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
 }
 
 #fs_modal h1, #fs_modal h2, #fs_modal h3, #fs_modal h4, #fs_modal h5, #fs_modal h6 {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #fs_modal_bg {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 #fs_modal.channel_options_modal .channel_option_item .channel_option_open {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #fs_modal.channel_options_modal .channel_option_item {
-  border-top-color: #363636;
+  border-top-color: var(--main-dark-highlight);
 }
 
 #fs_modal.channel_options_modal .channel_option_item:hover {
   background: rgba(0, 0, 0, 0.75);
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 #fs_modal.channel_options_modal .channel_options_header {
-  border-bottom-color: #363636;
+  border-bottom-color: var(--main-dark-highlight);
 }
 
 #fs_modal.channel_options_modal .convert_to_shared label {
@@ -7176,7 +7185,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #fs_modal.fs_modal_header .fs_modal_btn:active {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #fs_modal.help_modal .help_modal_article_row .channel_browser_open {
@@ -7184,7 +7193,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #fs_modal.help_modal .help_modal_article_row {
-  border-top: 1px solid #363636;
+  border-top: 1px solid var(--main-dark-highlight);
 }
 
 #fs_modal.help_modal .help_modal_divider {
@@ -7192,12 +7201,12 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #fs_modal.help_modal .help_modal_header {
-  background-color: #363636;
-  border-color: #545454;
+  background-color: var(--main-dark-highlight);
+  border-color: var(--main-highlight);
 }
 
 #fs_modal.help_modal .help_modal_header a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #fs_modal.help_modal #fs_modal_footer .help_modal_status #no_open_issues {
@@ -7205,7 +7214,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #fs_modal.help_modal #help_modal_list_container:not(.keyboard_active).not_scrolling .help_modal_article_row:hover, #fs_modal.help_modal .help_modal_article_row.highlighted {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   border-color: #000;
 }
 
@@ -7222,7 +7231,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #fs_modal.prefs_modal .channel_overrides_row .channel_overrides_summary {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #fs_modal.prefs_modal .channel_overrides_row {
@@ -7230,21 +7239,21 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #fs_modal.prefs_modal .channel_overrides_row:hover {
-  background: #363636;
+  background: var(--main-dark-highlight);
   border-color: #000;
 }
 
 #fs_modal.prefs_modal .display_real_names_block_sample {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 #fs_modal.prefs_modal .global_notification_block {
-  background: #222;
+  background: var(--main-bg-color);
   border-color: #000;
 }
 
 #fs_modal.prefs_modal .global_notification_block.selected {
-  background: #363636;
+  background: var(--main-dark-highlight);
   border-color: #000;
 }
 
@@ -7255,12 +7264,12 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 #fs_modal.prefs_modal .notification_example.linux, #fs_modal.prefs_modal .notification_example.windows {
   background: #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #fs_modal.prefs_modal .notification_example.mac {
   background: #000;
-  box-shadow: 0 1px 8px 2px #363636;
+  box-shadow: 0 1px 8px 2px var(--main-dark-highlight);
 }
 
 #fs_modal.prefs_modal #prefs_sidebar .theme_thumb {
@@ -7281,15 +7290,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 #fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .colpick {
   background: #424242;
-  border: 1px solid #363636;
+  border: 1px solid var(--main-dark-highlight);
 }
 
 #fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .custom_theme_label .color_swatch {
-  border: 1px solid #363636;
+  border: 1px solid var(--main-dark-highlight);
 }
 
 #fs_modal.prefs_modal #prefs_sidebar #prefs_themes_customize .custom_theme_label {
-  border: 1px solid #363636;
+  border: 1px solid var(--main-dark-highlight);
 }
 
 #fs_modal.prefs_modal label.sound_option:hover:not(.disabled) ts-icon {
@@ -7297,7 +7306,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #fs_modal.prefs_modal legend {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #generic_dialog.basic_share_dialog .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon), #share_dialog .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon) {
@@ -7305,16 +7314,16 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #home_footer a {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 #im_browser .im_browser_row .im_unread_cnt {
   background: #bf360c;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #im_browser .im_browser_row {
-  border-top: 1px solid #545454;
+  border-top: 1px solid var(--main-highlight);
 }
 
 #im_browser .im_browser_row.disabled {
@@ -7326,18 +7335,18 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #im_browser .im_browser_row.multiparty {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #im_browser #im_list_container:not(.keyboard_active).not_scrolling .im_browser_row:not(.disabled_dm):hover, #im_browser .im_browser_row.highlighted {
   background: #000 !important;
-  border: 1px solid #545454 !important;
+  border: 1px solid var(--main-highlight) !important;
 }
 
 #im_browser_tokens .member_token {
-  background: #222;
+  background: var(--main-bg-color);
   border: 1px solid #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #im_browser_tokens .member_token.ra {
@@ -7345,7 +7354,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #im_browser_tokens {
-  background: #545454;
+  background: var(--main-highlight);
   border: 1px solid #828282;
 }
 
@@ -7360,11 +7369,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 #incoming_call {
   background-color: rgba(0, 0, 0, 0.97);
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #invite_members_container .lfs_input_container {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 #limit_meter_message_body {
@@ -7372,7 +7381,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #limit_meter:hover #limit_meter_message_body {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #loading_message #loading_message_attribution {
@@ -7380,11 +7389,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #loading_message p {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #loading_team_menu_bg, #loading_user_menu_bg {
-  background: #222;
+  background: var(--main-bg-color);
   border: none;
 }
 
@@ -7402,7 +7411,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #member_preview_scroller .member_data_table .current_status_cell .current_status_container .current_status_cover:hover {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 #member_preview_scroller .member_data_table .current_status_cell .current_status_container:not(.active) .current_status_cover.without_status_set .current_status_placeholder {
@@ -7418,19 +7427,19 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #member_preview_scroller .member_data_table a:hover, #member_preview_web_container .member_data_table a:hover, #team_list .member_data_table a:hover, .menu_member_header .member_data_table a:hover {
-  color: #c7c7c7 !important;
+  color: var(--text-hover) !important;
 }
 
 #member_preview_scroller .member_data_table a:hover, #team_list .member_data_table a:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 #member_preview_scroller .member_data_table tr, #member_preview_web_container .member_data_table tr, #team_list .member_data_table tr, .menu_member_header .member_data_table tr {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #member_preview_scroller .member_details .member_name_and_presence .member_name, #member_preview_web_container .member_details .member_name_and_presence .member_name, .menu_member_header .member_details .member_name_and_presence .member_name {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #member_preview_scroller .member_details .member_restriction .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_restriction .ts_icon_question_circle:hover, #member_preview_scroller .member_details .member_timezone_value .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_timezone_value .ts_icon_question_circle:hover, #member_preview_scroller .member_details .member_current_status .ts_icon_question_circle:focus, #member_preview_scroller .member_details .member_current_status .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_restriction .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_restriction .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_timezone_value .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_timezone_value .ts_icon_question_circle:hover, #member_preview_web_container .member_details .member_current_status .ts_icon_question_circle:focus, #member_preview_web_container .member_details .member_current_status .ts_icon_question_circle:hover, .menu_member_header .member_details .member_restriction .ts_icon_question_circle:focus, .menu_member_header .member_details .member_restriction .ts_icon_question_circle:hover, .menu_member_header .member_details .member_timezone_value .ts_icon_question_circle:focus, .menu_member_header .member_details .member_timezone_value .ts_icon_question_circle:hover, .menu_member_header .member_details .member_current_status .ts_icon_question_circle:focus, .menu_member_header .member_details .member_current_status .ts_icon_question_circle:hover {
@@ -7442,7 +7451,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #member_preview_scroller .member_details .member_restriction a:hover, #member_preview_scroller .member_details .member_timezone_value a:hover, #member_preview_scroller .member_details .member_current_status a:hover, #member_preview_web_container .member_details .member_restriction a:hover, #member_preview_web_container .member_details .member_timezone_value a:hover, #member_preview_web_container .member_details .member_current_status a:hover, .menu_member_header .member_details .member_restriction a:hover, .menu_member_header .member_details .member_timezone_value a:hover, .menu_member_header .member_details .member_current_status a:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 #member_preview_scroller .member_details .member_restriction, #member_preview_scroller .member_details .member_timezone_value, #member_preview_scroller .member_details .member_current_status, #member_preview_web_container .member_details .member_restriction, #member_preview_web_container .member_details .member_timezone_value, #member_preview_web_container .member_details .member_current_status, .menu_member_header .member_details .member_restriction, .menu_member_header .member_details .member_timezone_value, .menu_member_header .member_details .member_current_status {
@@ -7450,15 +7459,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #member_preview_scroller .member_details .member_title, #member_preview_web_container .member_details .member_title, .menu_member_header .member_details .member_title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #member_preview_scroller .member_details_divider, #member_preview_web_container .member_details_divider, .menu_member_header .member_details_divider {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 #member_preview_scroller {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 #member_preview_scroller a:not(.member_name):not(.current_status_preset_option), .team_list_item a:not(.member_name):not(.current_status_preset_option) {
@@ -7466,7 +7475,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #member_preview_scroller a:not(.member_name):not(.current_status_preset_option):hover, .team_list_item a:not(.member_name):not(.current_status_preset_option):hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 #member_preview_scroller a.member_action_button, #team_list a.member_action_button {
@@ -7475,23 +7484,23 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 #member_preview_scroller a.member_action_button:hover, #team_list a.member_action_button:hover {
   border-color: #828282 !important;
-  color: #c7c7c7 !important;
+  color: var(--text-hover) !important;
 }
 
 #menu_items_scroller::-webkit-scrollbar-track {
-  background: #222 !important;
+  background: var(--main-bg-color) !important;
 }
 
 #menu.date_picker .pickmeup .pmu-instance .pmu-button:not(.pmu-disabled):hover, #menu.date_picker .pickmeup .pmu-selected {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 #menu.date_picker li.date_picker_item a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #menu.date_picker li.date_picker_item a:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #menu.date_picker li.date_picker_item.highlighted a {
@@ -7499,23 +7508,23 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #message_container #msg_limit {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #message_edit_container .inline_message_input_container, #message_edit_container .inline_message_input_container.with_file_upload, #threads_msgs .inline_message_input_container, #threads_msgs .inline_message_input_container.with_file_upload, #reply_container.upload_in_threads .inline_message_input_container, #reply_container.upload_in_threads .inline_message_input_container.with_file_upload {
-  background: #545454;
-  border-color: #363636;
-  color: #e6e6e6;
+  background: var(--main-highlight);
+  border-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 #message_edit_container .message_input {
-  background: #545454;
-  border-color: #363636;
-  color: #e6e6e6;
+  background: var(--main-highlight);
+  border-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 #message_edit_container .message_input.focus {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
   box-shadow: 0 0 7px rgba(0, 0, 0, 0.15);
 }
 
@@ -7524,7 +7533,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #message_edit_form .current_status_input.focus~.current_status_emoji_picker .current_status_empty_emoji, #msg_form .current_status_input.focus~.current_status_emoji_picker .current_status_empty_emoji, .current_status_container .current_status_input.focus~.current_status_emoji_picker .current_status_empty_emoji, .current_status_input_container .current_status_input.focus~.current_status_emoji_picker .current_status_empty_emoji, .inline_message_input_container .current_status_input.focus~.current_status_emoji_picker .current_status_empty_emoji, .share_channel_modal_contents .current_status_input.focus~.current_status_emoji_picker .current_status_empty_emoji {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #message_edit_form .emo_menu {
@@ -7536,11 +7545,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #message_edit_form .message_input:focus~#primary_file_button:not(:hover):not(.active), #message_edit_form .message_input:focus~.emo_menu, #msg_form .message_input:focus~#primary_file_button:not(:hover):not(.active), #msg_form .message_input:focus~.emo_menu, .current_status_container .message_input:focus~#primary_file_button:not(:hover):not(.active), .current_status_container .message_input:focus~.emo_menu, .current_status_input_container .message_input:focus~#primary_file_button:not(:hover):not(.active), .current_status_input_container .message_input:focus~.emo_menu, .inline_message_input_container .message_input:focus~#primary_file_button:not(:hover):not(.active), .inline_message_input_container .message_input:focus~.emo_menu, .share_channel_modal_contents .message_input:focus~#primary_file_button:not(:hover):not(.active), .share_channel_modal_contents .message_input:focus~.emo_menu {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #message_edit_form #msg_input.focus~#primary_file_button:not(:hover):not(.active), #message_edit_form #msg_input.focus~.emo_menu, #message_edit_form #msg_input:focus~#primary_file_button:not(:hover):not(.active), #message_edit_form #msg_input:focus~.emo_menu, #msg_form #msg_input.focus~#primary_file_button:not(:hover):not(.active), #msg_form #msg_input.focus~.emo_menu, #msg_form #msg_input:focus~#primary_file_button:not(:hover):not(.active), #msg_form #msg_input:focus~.emo_menu, .current_status_container #msg_input.focus~#primary_file_button:not(:hover):not(.active), .current_status_container #msg_input.focus~.emo_menu, .current_status_container #msg_input:focus~#primary_file_button:not(:hover):not(.active), .current_status_container #msg_input:focus~.emo_menu, .current_status_input_container #msg_input.focus~#primary_file_button:not(:hover):not(.active), .current_status_input_container #msg_input.focus~.emo_menu, .current_status_input_container #msg_input:focus~#primary_file_button:not(:hover):not(.active), .current_status_input_container #msg_input:focus~.emo_menu, .inline_message_input_container #msg_input.focus~#primary_file_button:not(:hover):not(.active), .inline_message_input_container #msg_input.focus~.emo_menu, .inline_message_input_container #msg_input:focus~#primary_file_button:not(:hover):not(.active), .inline_message_input_container #msg_input:focus~.emo_menu, .share_channel_modal_contents #msg_input.focus~#primary_file_button:not(:hover):not(.active), .share_channel_modal_contents #msg_input.focus~.emo_menu, .share_channel_modal_contents #msg_input:focus~#primary_file_button:not(:hover):not(.active), .share_channel_modal_contents #msg_input:focus~.emo_menu {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #message_edit_form.focus .emo_menu {
@@ -7548,11 +7557,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #message_edit_form.focus #primary_file_button:not(:hover) {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 #message_edit_form.offline #message-input, #message_edit_form.offline #primary_file_button {
-  background-color: #363636 !important;
+  background-color: var(--main-dark-highlight) !important;
 }
 
 #message_edit_form.offline #primary_file_button {
@@ -7565,7 +7574,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #messages_unread_status {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 #messages_unread_status:hover .clear_unread_messages {
@@ -7573,7 +7582,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #messages_unread_status:hover .clear_unread_messages:hover {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 #messages_unread_status:hover {
@@ -7582,12 +7591,12 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 #messages_unread_status.quiet {
   background: #828282;
-  color: #e6e6e6;
+  color: var(--main-text);
   text-shadow: 0 1px rgba(0, 0, 0, 0.15);
 }
 
 #messages_unread_status.quiet a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #msg_form .msg_mentions_button {
@@ -7595,28 +7604,28 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #msg_form .msg_mentions_button:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #msg_form #msg_input {
-  background: padding-box #545454;
+  background: padding-box var(--main-highlight);
   border-color: #424242;
   border-left: 0;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #msg_form #msg_input.focus~.msg_mentions_button:not(.hover) {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #msg_form.focus #msg_input, #msg_form.focus #primary_file_button:not(:hover):not(.active) {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 #msg_input {
-  background: #545454;
+  background: var(--main-highlight);
   border-color: #424242;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #msg_input+#primary_file_button:not(:hover):not(.active) {
@@ -7628,59 +7637,59 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #msg_input_message {
-  background-color: #363636;
-  color: #e6e6e6;
+  background-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 #msg_input::-moz-placeholder {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
   filter: none;
   opacity: 0.5;
 }
 
 #msg_input::-webkit-input-placeholder {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
   -webkit-filter: none;
   filter: none;
   opacity: 0.5;
 }
 
 #msg_input::placeholder {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
   filter: none;
   opacity: 0.5;
 }
 
 #msg_input:focus+#primary_file_button:not(:hover):not(.active), #msg_input.focus+#primary_file_button:not(:hover):not(.active) {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 #msg_input:focus, #msg_input.focus {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 #msg_input.disabled, #msg_input.ql-disabled {
-  background-color: #363636;
-  border-color: #363636;
+  background-color: var(--main-dark-highlight);
+  border-color: var(--main-dark-highlight);
   color: #949494;
 }
 
 #msg_input.offline:not(.pretend-to-be-online) {
-  background-color: #363636 !important;
+  background-color: var(--main-dark-highlight) !important;
   color: #949494;
 }
 
 #msg_input[data-placeholder]:empty::before {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 #msgs_div .unread_divider .divider_label {
-  background: #222;
-  color: #545454;
+  background: var(--main-bg-color);
+  color: var(--main-highlight);
 }
 
 #msgs_div .unread_divider hr {
-  border-top: 1px solid #545454;
+  border-top: 1px solid var(--main-highlight);
 }
 
 #msgs_div .unread_divider.no_unreads .divider_label {
@@ -7688,11 +7697,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #msgs_div .unread_divider.no_unreads hr {
-  border-top-color: #363636;
+  border-top-color: var(--main-dark-highlight);
 }
 
 #msgs_overlay_div {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 #msgs_scroller_div #end_display_div #end_display_meta {
@@ -7700,7 +7709,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #msgs_scroller_div #end_display_div #end_display_meta h1 {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #msgs_scroller_div #end_display_div #end_display_status {
@@ -7708,7 +7717,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #msgs_scroller_div #end_display_div p {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #notification_bar.wide #typing_text.overflow_ellipsis {
@@ -7717,37 +7726,37 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #notifications_not_working p.highlight_yellow_bg a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #page .app_desc_btn {
-  background-color: #545454;
-  color: #e6e6e6;
+  background-color: var(--main-highlight);
+  color: var(--main-text);
 }
 
 #page .app_desc_expand_showing .app_profile_desc_fade {
-  background: linear-gradient(180deg, rgba(34, 34, 34, 0) 0, #222 100%);
+  background: linear-gradient(180deg, rgba(34, 34, 34, 0) 0, var(--main-bg-color) 100%);
 }
 
 #page .media_list {
-  background-color: #363636;
-  border: 1px solid #545454;
+  background-color: var(--main-dark-highlight);
+  border: 1px solid var(--main-highlight);
 }
 
 #page .media_list>li .media_list_text {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #page .media_list>li+li::before {
-  border-top-color: #545454;
+  border-top-color: var(--main-highlight);
 }
 
 #page .media_list>li.interactive a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #page .media_list>li.interactive a:focus, #page .media_list>li.interactive a:hover {
-  background: #545454;
+  background: var(--main-highlight);
   border-color: #828282;
 }
 
@@ -7756,7 +7765,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #page .media_list_title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #page .media_list.media_list_with_arrows a::before {
@@ -7764,50 +7773,50 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #page .service_card {
-  background-color: #222;
+  background-color: var(--main-bg-color);
   border: 1px solid #424242;
 }
 
 #page .service_panel {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 #page .sidebar_menu_list_item {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #page .sidebar_menu_list_item a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #page .sidebar_menu_list_item:not(.is_active):hover {
-  background-color: #222;
-  border-color: #222;
+  background-color: var(--main-bg-color);
+  border-color: var(--main-bg-color);
 }
 
 #page .sidebar_menu_list_item.is_active {
-  background-color: #222;
-  border-color: #222;
-  color: #e6e6e6;
+  background-color: var(--main-bg-color);
+  border-color: var(--main-bg-color);
+  color: var(--main-text);
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
 }
 
 #page .sidebar_menu_list_item.is_active a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #page .tag {
   background-color: #000;
-  border: 1px solid #363636;
+  border: 1px solid var(--main-dark-highlight);
 }
 
 #page .tag:hover {
-  background-color: #545454 !important;
+  background-color: var(--main-highlight) !important;
 }
 
 #page pre, body>pre {
   background: #000;
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 #page ul.breadcrumbs li {
@@ -7823,15 +7832,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #page ul.navigation_list li a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #page ul.navigation_list li a::after {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #page ul.navigation_list li a:hover {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 #page_contents .card {
@@ -7839,7 +7848,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #page_contents .card p {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #paging_in_options .search_paging {
@@ -7847,24 +7856,24 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #prefs_dnd p {
-  color: #e6e6e6
+  color: var(--main-text)
 }
 
 #primary_file_button {
-  background: padding-box #545454;
+  background: padding-box var(--main-highlight);
   border-color: #424242;
   color: #949494;
 }
 
 #primary_file_button.active, #primary_file_button.focus-ring, #primary_file_button:focus, #primary_file_button:hover {
   background: #424242;
-  border-color: #363636;
-  color: #e6e6e6;
+  border-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 #quick_switcher_btn {
-  background: #363636;
-  border-top: 2px solid #363636;
+  background: var(--main-dark-highlight);
+  border-top: 2px solid var(--main-dark-highlight);
 }
 
 #quick_switcher_btn>i {
@@ -7880,8 +7889,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #quick_switcher_btn:active, #quick_switcher_btn:hover {
-  background: #222;
-  border-color: #222;
+  background: var(--main-bg-color);
+  border-color: var(--main-bg-color);
 }
 
 #quick_switcher_label {
@@ -7893,8 +7902,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #reply_container .inline_message_input_container .message_input div, #reply_container .inline_message_input_container textarea, .reply_input_container .inline_message_input_container .message_input div, .reply_input_container .inline_message_input_container textarea {
-  border-color: #363636;
-  color: #e6e6e6;
+  border-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 #reply_container .inline_message_input_container .message_input div:active, #reply_container .inline_message_input_container .message_input div:focus, #reply_container .inline_message_input_container textarea:active, #reply_container .inline_message_input_container textarea:focus, .reply_input_container .inline_message_input_container .message_input div:active, .reply_input_container .inline_message_input_container .message_input div:focus, .reply_input_container .inline_message_input_container textarea:active, .reply_input_container .inline_message_input_container textarea:focus {
@@ -7906,17 +7915,17 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #reply_container .reply_broadcast_buttons_container .reply_broadcast_label_container, .reply_input_container .reply_broadcast_buttons_container .reply_broadcast_label_container {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #reply_container .reply_limited_in_general, .reply_input_container .reply_limited_in_general {
-  background: #222;
+  background: var(--main-bg-color);
   color: #949494;
 }
 
 #rxn_toast_div {
   background: #000;
-  border: 1px solid #545454;
+  border: 1px solid var(--main-highlight);
 }
 
 #search_container .icon_close {
@@ -7932,36 +7941,36 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #search_file_list_toggle_users.active:hover {
-  border: 2px solid #c7c7c7;
-  color: #c7c7c7 !important;
+  border: 2px solid var(--text-hover);
+  color: var(--text-hover) !important;
 }
 
 #search_filters .tab {
-  background: #222;
-  color: #e6e6e6;
+  background: var(--main-bg-color);
+  color: var(--main-text);
 }
 
 #search_filters .tab:hover {
-  border-bottom: 4px solid #363636;
+  border-bottom: 4px solid var(--main-dark-highlight);
 }
 
 #search_filters.files #filter_files, #search_filters.messages #filter_messages {
-  border-bottom: 4px solid #363636;
-  color: #e6e6e6;
+  border-bottom: 4px solid var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 #search_results_items .search_paging {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #search_results_team .member_name {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 #search_results_team .team_result {
-  background-color: #545454;
+  background-color: var(--main-highlight);
   border-color: #828282;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #search_results_team .team_result a {
@@ -7969,19 +7978,19 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #search_results_team .team_result a:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 #search_results_team .team_result:hover a {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 #search_results_team .team_results_heading {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #search_spinner {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #select_share_channels .lazy_filter_select .lfs_item .ts_icon:not(.presence_icon) {
@@ -7997,7 +8006,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #select_share_channels .lazy_filter_select .lfs_value .lfs_item.selected {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 #share_dialog .file_list_item {
@@ -8005,15 +8014,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #share_dialog_input_container #file_comment_textarea.ql-container {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 #share_dialog_input_container #file_comment_textarea.ql-container.focus {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 #share_dialog_input_container #file_comment_textarea.ql-container.focus~.emo_menu {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #shortcuts_dialog {
@@ -8022,10 +8031,10 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #shortcuts_dialog.modal .close {
-  background: #545454;
+  background: var(--main-highlight);
   border-color: #828282;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #shortcuts_dialog.modal .close:hover {
@@ -8037,11 +8046,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #shortcuts_dialog.modal .modal-body, #shortcuts_dialog.modal h1, #shortcuts_dialog.modal h3 {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #shortcuts_dialog.modal ul ul {
-  border-left-color: #545454;
+  border-left-color: var(--main-highlight);
 }
 
 #shortcuts_spaces_dialog .close .ts_icon::before {
@@ -8056,11 +8065,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
   background-color: #828282;
   border-bottom: 2px solid #424242;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #shortcuts_spaces_dialog .modal-body {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #shortcuts_spaces_dialog {
@@ -8070,11 +8079,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 #space_alert .btn_outline.btn_transparent {
   background-color: #424242 !important;
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 #space_alert .btn_outline.btn_transparent::after {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 #space_alert {
@@ -8095,7 +8104,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #space_alert span#space_alert_text {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #space_alert.error {
@@ -8103,7 +8112,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #space_find_bar {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   border-bottom: 1px solid rgba(130, 130, 130, 0.1);
   border-left: 1px solid rgba(130, 130, 130, 0.07);
   border-right: 1px solid rgba(130, 130, 130, 0.07);
@@ -8123,11 +8132,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #space_find_bar #space_find_next .ts_icon {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 #space_find_bar #space_find_next .ts_icon::before, #space_find_bar #space_find_next .ts_icon:hover::before {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #space_find_bar #space_find_next:hover .ts_icon {
@@ -8155,11 +8164,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #team_filter a.icon_close:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 #team_filter a.icon_close:hover, #user_group_filter a.icon_close:hover, .searchable_member_list_search_bar a.icon_close:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 #team_menu .presence .presence_icon {
@@ -8167,15 +8176,15 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #team_menu .team_name_caret, #team_menu .notifications_menu_btn {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 #team_menu {
-  background: #222;
-  background-color: #222;
-  border-color: #222 !important;
-  border-bottom: 2px solid #222;
-  color: #e6e6e6;
+  background: var(--main-bg-color);
+  background-color: var(--main-bg-color);
+  border-color: var(--main-bg-color) !important;
+  border-bottom: 2px solid var(--main-bg-color);
+  color: var(--main-text);
 }
 
 #team_menu i {
@@ -8187,37 +8196,37 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #team_menu_user_name, #team_menu_user_details {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
   opacity: 0.75;
 }
 
 #team_menu.active i, #team_menu:hover i {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #team_menu.active, #team_menu:hover {
-  background: #363636 !important;
-  border-bottom-color: #363636 !important;
+  background: var(--main-dark-highlight) !important;
+  border-bottom-color: var(--main-dark-highlight) !important;
 }
 
 #team_tab #member_preview_scroller .member_details .member_name {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 #team_tab #member_preview_scroller {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 #threads_view_banner.messages_banner {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 #threads_view_banner.messages_banner:hover .clear_unread_messages {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 #threads_view_banner.messages_banner:hover {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 #toggle-subscription-status .subscription_desc {
@@ -8230,7 +8239,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #unread_msgs_div .day_divider .day_divider_line {
-  border-top-color: #363636;
+  border-top-color: var(--main-dark-highlight);
 }
 
 #unread_msgs_scroller_div::after {
@@ -8251,8 +8260,8 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #user_groups_container .info_panel {
-  background: #222;
-  border: 1px solid #545454;
+  background: var(--main-bg-color);
+  border: 1px solid var(--main-highlight);
 }
 
 #user_groups_container .mention {
@@ -8268,7 +8277,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #user_groups_header a.icon_close:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 #user_groups_pane .mention {
@@ -8283,7 +8292,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 #whats_new_tab p {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link, a.c-member_slug.active,
@@ -8298,12 +8307,12 @@ a.c-tabs__tab--plastic {
 }
 
 a.c-tabs__tab--plastic:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 a.c-tabs__tab--plastic.c-tabs__tab--active, a.c-tabs__tab--plastic:active, a.c-tabs__tab--plastic:focus {
   box-shadow: inset 0 -2px 0 0 #828282;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 a.file_download_link, a.file_download_link:hover {
@@ -8311,21 +8320,21 @@ a.file_download_link, a.file_download_link:hover {
 }
 
 a.filetype_button_web .filetype_icon {
-  background-color: #545454;
+  background-color: var(--main-highlight);
 }
 
 a.filetype_button_web {
   background: #828282;
-  border: 1px solid #545454;
-  color: #e6e6e6;
+  border: 1px solid var(--main-highlight);
+  color: var(--main-text);
 }
 
 a.gsheet img, a.pdf img {
-  background: #222 !important;
+  background: var(--main-bg-color) !important;
 }
 
 a.internal_member_link {
-  background: #363636;
+  background: var(--main-dark-highlight);
   color: #3aa3e3;
 }
 
@@ -8334,7 +8343,7 @@ a.p-oauth_nav__anchor {
 }
 
 a.plastic_typeahead_item {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 a.splash_interactive__window_link {
@@ -8342,8 +8351,8 @@ a.splash_interactive__window_link {
 }
 
 a.two_factor_choice {
-  background-color: #363636;
-  border: 1px solid #545454;
+  background-color: var(--main-dark-highlight);
+  border: 1px solid var(--main-highlight);
   box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25);
 }
 
@@ -8356,14 +8365,14 @@ a.two_factor_choice:hover, a.two_factor_choice:link:hover {
 }
 
 a.two_factor_choice:link {
-  background-color: #363636;
-  border: 1px solid #545454;
+  background-color: var(--main-dark-highlight);
+  border: 1px solid var(--main-highlight);
   box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25);
 }
 
 body {
-  background: #222;
-  color: #e6e6e6;
+  background: var(--main-bg-color);
+  color: var(--main-text);
 }
 
 body>pre {
@@ -8371,7 +8380,7 @@ body>pre {
 }
 
 body.api .alert {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 body.api .example {
@@ -8380,7 +8389,7 @@ body.api .example {
 
 body.api .example h5 {
   background-color: #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 body.api .hljs {
@@ -8453,7 +8462,7 @@ body.api .hljs-variable {
 
 body.api .reverse_header {
   background-color: #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 body.api .scopes_to_methods .selected code {
@@ -8461,31 +8470,31 @@ body.api .scopes_to_methods .selected code {
 }
 
 body.api .scopes_to_methods .selected li {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 body.api .scopes_to_methods code {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 body.api .scopes_to_methods li {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 body.api .section_title {
-  border-bottom: 2px solid #222;
+  border-bottom: 2px solid var(--main-bg-color);
 }
 
 body.api #page_contents .card {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 body.api header .header_links a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 body.api header .header_links a.active {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 body.api pre {
@@ -8493,11 +8502,11 @@ body.api pre {
 }
 
 body.api pre code {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 body.api span.btn {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 body.api span.deprecation, body.api span.warning {
@@ -8506,19 +8515,19 @@ body.api span.deprecation, body.api span.warning {
 }
 
 body.loading #team_menu, body.loading #quick_switcher_btn, body.loading #team_menu_overlay, body.loading #col_channels_overlay, body.loading #col_channels {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 code {
   background-color: #000;
-  border: 1px solid #363636;
-  color: #e6e6e6;
+  border: 1px solid var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 code a.app_preview_link {
-  background: #363636;
-  border: 1px solid #545454;
-  color: #e6e6e6;
+  background: var(--main-dark-highlight);
+  border: 1px solid var(--main-highlight);
+  color: var(--main-text);
 }
 
 comments {
@@ -8534,7 +8543,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {
 }
 
 footer ul a, #autocomplete_menu.search_menu footer.unified ul a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 footer ul a:link, footer ul a:visited, #autocomplete_menu.search_menu footer.unified ul a:link, #autocomplete_menu.search_menu footer.unified ul a:visited {
@@ -8542,13 +8551,13 @@ footer ul a:link, footer ul a:visited, #autocomplete_menu.search_menu footer.uni
 }
 
 footer, #autocomplete_menu.search_menu footer.unified {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   border-color: #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 h1 a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 h1 a:active, h1 a:hover, h1 a:link, h1 a:visited {
@@ -8556,7 +8565,7 @@ h1 a:active, h1 a:hover, h1 a:link, h1 a:visited {
 }
 
 h1, h2, h3, h4 {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 header .header_btns a .label {
@@ -8572,11 +8581,11 @@ header .vert_divider {
 }
 
 header {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 header #header_team_nav {
-  background: #363636;
+  background: var(--main-dark-highlight);
   border: 1px solid #000;
 }
 
@@ -8590,17 +8599,17 @@ header #header_team_nav li a .team_icon.ts_icon_plus {
 }
 
 header #header_team_nav li a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 header #header_team_nav li a:hover {
-  background: #222;
-  color: #e6e6e6;
+  background: var(--main-bg-color);
+  color: var(--main-text);
 }
 
 header #header_team_nav li.active a {
-  background: #222;
-  color: #e6e6e6;
+  background: var(--main-bg-color);
+  color: var(--main-text);
 }
 
 header #menu_toggle {
@@ -8609,23 +8618,23 @@ header #menu_toggle {
 
 hr {
   border-bottom: 1px solid #424242;
-  border-top: 1px solid #222;
+  border-top: 1px solid var(--main-bg-color);
 }
 
 html.no_touch .action_cog:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 html.no_touch .action_cog:hover i {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 html.no_touch .pager li>a:hover, html.no_touch .pager li>a:focus {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 html.no_touch .pagination ul>.disabled>a:hover {
-  background: #363636;
+  background: var(--main-dark-highlight);
   color: #949494;
 }
 
@@ -8634,20 +8643,20 @@ html.no_touch .pagination ul>li>a:hover {
 }
 
 html.no_touch .plastic_row:hover .chevron {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 html.no_touch .plastic_row:hover {
-  background: #222;
+  background: var(--main-bg-color);
   border-color: #000;
 }
 
 html.no_touch a.filetype_button_web:hover .file_title {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 html.no_touch a.filetype_button_web:hover {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 html.no_touch header .header_btns a:hover .label {
@@ -8655,37 +8664,37 @@ html.no_touch header .header_btns a:hover .label {
 }
 
 html.no_touch header .header_btns a:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 html.no_touch header #header_team_name a:hover, html.no_touch header #menu_toggle:hover {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 html.no_touch header #header_team_nav li a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 html.no_touch header #header_team_nav li a:hover {
-  background: #222;
-  color: #e6e6e6;
+  background: var(--main-bg-color);
+  color: var(--main-text);
 }
 
 input::-moz-placeholder, textarea::-moz-placeholder {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
   filter: none;
   opacity: 0.5;
 }
 
 input::-webkit-input-placeholder, textarea::-webkit-input-placeholder {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
   -webkit-filter: none;
   filter: none;
   opacity: 0.5;
 }
 
 input::placeholder, textarea::placeholder {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
   filter: none;
   opacity: 0.5;
 }
@@ -8695,30 +8704,30 @@ input:disabled, input:disabled:active, select:disabled, textarea:disabled {
 }
 
 input[data-placeholder]:empty::before, textarea[data-placeholder]:empty::before {
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 input[disabled], input[readonly], textarea[disabled], textarea[readonly] {
-  background-color: #545454 !important;
+  background-color: var(--main-highlight) !important;
 }
 
 input[type="text"].p-emoji_picker__input:focus {
-  border-color: #545454;
+  border-color: var(--main-highlight);
   box-shadow: none;
 }
 
 input[type=file]:focus {
-  outline: #e6e6e6 dotted thin;
+  outline: var(--main-text) dotted thin;
 }
 
 input[type=radio]:focus, input[type=checkbox]:focus {
-  outline: #e6e6e6 dotted thin;
+  outline: var(--main-text) dotted thin;
 }
 
 input[type=text], input[type=password], input[type=datetime], input[type=datetime-local], input[type=date], input[type=month], input[type=time], input[type=week], input[type=number], input[type=email], input[type='url'], input[type=tel], input[type=color], input[type=search] {
-  background-color: #545454;
+  background-color: var(--main-highlight);
   border-color: #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 input[type=text]:focus, input[type=password]:focus, input[type=datetime]:focus, input[type=datetime-local]:focus, input[type=date]:focus, input[type=month]:focus, input[type=time]:focus, input[type=week]:focus, input[type=number]:focus, input[type=email]:focus, input[type='url']:focus, input[type=tel]:focus, input[type=color]:focus, input[type=search]:focus {
@@ -8727,7 +8736,7 @@ input[type=text]:focus, input[type=password]:focus, input[type=datetime]:focus, 
 }
 
 label.disabled {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 legend {
@@ -8739,7 +8748,7 @@ legend small {
 }
 
 nav .comments {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
 }
 
 nav .comments_close {
@@ -8756,12 +8765,12 @@ nav .comments_open.unread span.notif {
 }
 
 nav .space {
-  background-color: #363636;
+  background-color: var(--main-dark-highlight);
   box-shadow: 0 1px rgba(0, 0, 0, 0.25), 0 2px rgba(0, 0, 0, 0.15), 0 3px rgba(0, 0, 0, 0.15);
 }
 
 nav .space_btn_edit {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 nav .space_btn_edit.editing {
@@ -8782,11 +8791,11 @@ nav .space_buttons .btn_outline {
 }
 
 nav .space_buttons .btn_outline::after {
-  border-color: #545454;
+  border-color: var(--main-highlight);
 }
 
 nav .space::after {
-  border-left: 1px solid #545454;
+  border-left: 1px solid var(--main-highlight);
 }
 
 nav .star_info {
@@ -8794,7 +8803,7 @@ nav .star_info {
 }
 
 nav {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 nav #edit_status {
@@ -8802,7 +8811,7 @@ nav #edit_status {
 }
 
 nav #space_status {
-  border-left: 1px solid #545454;
+  border-left: 1px solid var(--main-highlight);
   color: #949494;
 }
 
@@ -8811,7 +8820,7 @@ nav #space_status.slightly_concerned {
 }
 
 nav.top.apps_nav .nav_title a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 nav.top.apps_nav {
@@ -8819,11 +8828,11 @@ nav.top.apps_nav {
 }
 
 nav.top.apps_nav ul a.active {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 nav.top.apps_nav.clear_nav .nav_title a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 nav.top.apps_nav.persistent .nav_title {
@@ -8835,11 +8844,11 @@ nav.top.persistent .logo {
 }
 
 nav.top.persistent {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 nav.top.persistent ul a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 nav#api_nav {
@@ -8848,16 +8857,16 @@ nav#api_nav {
 }
 
 nav#site_nav {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 nav#site_nav #footer_nav a, #header_team_name:hover .fa-caret-down, .widescreen:not(.nav_open) nav#site_nav #footer_nav a {
-  color: #c7c7c7;
+  color: var(--text-hover);
 }
 
 nav#site_nav #user_menu_contents:hover {
-  background: #222;
-  color: #e6e6e6;
+  background: var(--main-bg-color);
+  color: var(--main-text);
 }
 
 nav#site_nav h3, #header_team_name, header #header_team_name a {
@@ -8866,8 +8875,8 @@ nav#site_nav h3, #header_team_name, header #header_team_name a {
 
 pre {
   background: #000;
-  border: 1px solid #363636;
-  color: #e6e6e6;
+  border: 1px solid var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 pre span.mention {
@@ -8875,16 +8884,16 @@ pre span.mention {
 }
 
 select {
-  background: #545454;
+  background: var(--main-highlight);
 }
 
 select, textarea {
   border: 1px solid #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 select:active, select:focus, textarea:active, textarea:focus {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
   box-shadow: 0 0 7px rgba(130, 130, 130, 0.15);
 }
 
@@ -8893,7 +8902,7 @@ span.match {
 }
 
 table tr {
-  border-bottom-color: #222;
+  border-bottom-color: var(--main-bg-color);
 }
 
 table tr:first-child th:not(:only-of-type) {
@@ -8901,17 +8910,17 @@ table tr:first-child th:not(:only-of-type) {
 }
 
 table.billing tr:hover td {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 table.gray_header_border tr:first-child th:not(:only-of-type) {
-  border-bottom-color: #545454;
+  border-bottom-color: var(--main-highlight);
 }
 
 textarea {
-  background-color: #545454;
+  background-color: var(--main-highlight);
   border: 1px solid #000;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 textarea:focus {
@@ -8925,16 +8934,16 @@ textarea.c-input_textarea.c-input_textarea--with_hint {
 
 ts-jumper input[type=text] {
   border: 1px solid #000 !important;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 ts-jumper input[type=text]::-webkit-input-placeholder, ts-jumper input[type=text]:focus::-webkit-input-placeholder, ts-jumper input[type=text]::-moz-placeholder, ts-jumper input[type=text]:focus::-moz-placeholder {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 ts-jumper input[type=text]:focus {
   border: 1px solid rgba(54, 54, 54, 0.8) !important;
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 ts-jumper ol li .channel_name, ts-jumper ol li .member_real_name, ts-jumper ol li .member_username, ts-jumper ol li .team_username {
@@ -8947,70 +8956,70 @@ ts-jumper ol li .channel_not_member, ts-jumper ol li .team_username, ts-jumper o
 
 ts-jumper ol li .unread_count {
   background: #bf360c;
-  color: #e6e6e6;
+  color: var(--main-text);
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.25);
 }
 
 ts-jumper ol li {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 ts-jumper ol li.highlighted .channel_not_member, ts-jumper ol li.highlighted .member_real_name+.member_username, ts-jumper ol li.highlighted .member_username+.member_real_name, ts-jumper ol li.highlighted i.presence_icon, ts-jumper ol li.highlighted ts-icon, ts-jumper ol:not(.keyboard_active) li:hover .channel_not_member, ts-jumper ol:not(.keyboard_active) li:hover .member_real_name+.member_username, ts-jumper ol:not(.keyboard_active) li:hover .member_username+.member_real_name, ts-jumper ol:not(.keyboard_active) li:hover i.presence_icon, ts-jumper ol:not(.keyboard_active) li:hover ts-icon {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 ts-jumper ol li.highlighted {
   background: #828282 !important;
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 ts-jumper ol:not(.keyboard_active) li:hover {
   background: #828282 !important;
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 ts-jumper ts-jumper-container {
-  background: #222;
+  background: var(--main-bg-color);
   box-shadow: 0 1px 10px rgba(0, 0, 0, 0.5);
 }
 
 ts-jumper ts-jumper-help, ts-jumper .p-jumper__help {
-  background: #222;
+  background: var(--main-bg-color);
   color: #949494;
 }
 
 ts-mention {
   background: rgba(130, 130, 130, 0.1) !important;
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 ts-message .action_hover_container .btn_msg_action {
-  background: #222;
-  border-right: 1px solid #363636;
+  background: var(--main-bg-color);
+  border-right: 1px solid var(--main-dark-highlight);
   color: #949494;
 }
 
 ts-message .action_hover_container .btn_msg_action:hover {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 ts-message .action_hover_container .btn_msg_action.active, ts-message .action_hover_container .btn_msg_action:active {
-  background: #363636;
-  color: #e6e6e6;
+  background: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 ts-message .action_hover_container {
-  border: 1px solid #363636;
+  border: 1px solid var(--main-dark-highlight);
 }
 
 ts-message .action_hover_container:hover {
-  border-color: #545454;
+  border-color: var(--main-highlight);
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25);
 }
 
 ts-message .action_hover_container:hover a {
-  background: #363636;
-  border-right: 1px solid #545454;
+  background: var(--main-dark-highlight);
+  border-right: 1px solid var(--main-highlight);
 }
 
 ts-message .bot_label {
@@ -9028,17 +9037,17 @@ ts-message .in_reply_to {
 }
 
 ts-message .internal_member_link {
-  background: #222 !important;
+  background: var(--main-bg-color) !important;
   border: 0;
   color: #949494 !important;
 }
 
 ts-message .internal_member_link:hover {
-  color: #c7c7c7 !important;
+  color: var(--text-hover) !important;
 }
 
 ts-message .is_highlights_holder .highlights_feedback a:not(.highlights_feedback_link) {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 ts-message .is_highlights_holder .highlights_feedback_link {
@@ -9055,7 +9064,7 @@ ts-message .is_highlights_holder ts-icon {
 
 ts-message .mention {
   background: #828282 !important;
-  color: #e6e6e6 !important;
+  color: var(--main-text) !important;
 }
 
 ts-message .meta {
@@ -9083,7 +9092,7 @@ ts-message .recap_highlight {
 }
 
 ts-message .recap_highlight a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 ts-message .reply_bar .reply_bar_caret, ts-message .reply_bar .view_conv_hover, ts-message .reply_bar .last_reply_at {
@@ -9091,7 +9100,7 @@ ts-message .reply_bar .reply_bar_caret, ts-message .reply_bar .view_conv_hover, 
 }
 
 ts-message .reply_bar:hover {
-  background: #222;
+  background: var(--main-bg-color);
   border-color: #000;
 }
 
@@ -9104,7 +9113,7 @@ ts-message .timestamp {
 }
 
 ts-message {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 ts-message:hover .edited {
@@ -9125,7 +9134,7 @@ ts-message.active .meta.msg_inline_file_preview_toggler a, ts-message.message--f
 
 ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply) {
   background: rgba(0, 0, 0, 0.1);
-  box-shadow: inset 1px 0 0 0 #222;
+  box-shadow: inset 1px 0 0 0 var(--main-bg-color);
 }
 
 ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).is_pinned, ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply).show_recap:not(.is_pinned) {
@@ -9141,7 +9150,7 @@ ts-message.delete_mode, ts-message.multi_delete_mode {
 }
 
 ts-message.ephemeral {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 ts-message.highlight {
@@ -9157,11 +9166,11 @@ ts-message.is_pinned {
 }
 
 ts-message.message:hover, ts-message.message:active, ts-message.active:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator), ts-message.message--focus:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator), ts-message:hover:not(.standalone):not(.multi_delete_mode):not(.highlight):not(.new_reply):not(.show_broadcast_indicator) {
-  background-color: #222222;
+  background-color: var(--main-bg-color);
 }
 
 ts-message.selected {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 ts-message.selected:hover {
@@ -9169,7 +9178,7 @@ ts-message.selected:hover {
 }
 
 ts-message.selected:not(.delete_mode) {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 ts-message.show_recap:not(.is_pinned) {
@@ -9181,7 +9190,7 @@ ts-message.show_recap:not(.is_pinned):hover {
 }
 
 ts-message.standalone:not(.for_mention_display):not(.for_search_display):not(.for_top_results_search_display):not(.for_star_display) {
-  border: 1px solid #363636;
+  border: 1px solid var(--main-dark-highlight);
 }
 
 ts-message.unprocessed {
@@ -9198,7 +9207,7 @@ ts-rocket .cl.text .checkbox.checked+li {
 
 ts-rocket .cl.text {
   background-color: #000;
-  border-bottom: 1px solid #363636;
+  border-bottom: 1px solid var(--main-dark-highlight);
 }
 
 ts-rocket .hr.selected hr {
@@ -9206,7 +9215,7 @@ ts-rocket .hr.selected hr {
 }
 
 ts-rocket .unfurl .attachment_bar {
-  background-color: #363636 !important;
+  background-color: var(--main-dark-highlight) !important;
 }
 
 ts-rocket .unfurl .unfurl-container {
@@ -9222,7 +9231,7 @@ ts-rocket .unfurl .unfurl-remove::before {
 }
 
 ts-rocket .unfurl .unfurl-remove:hover::before {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 ts-rocket .unfurl.selected .unfurl-container .attachment_bar {
@@ -9234,7 +9243,7 @@ ts-rocket .unfurl.selected .unfurl-container {
 }
 
 ts-rocket {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 ts-rocket>div>.checklist .checkbox.checked+li {
@@ -9243,11 +9252,11 @@ ts-rocket>div>.checklist .checkbox.checked+li {
 
 ts-rocket>div>.checklist {
   background-color: #000;
-  border-bottom: 1px solid #363636;
+  border-bottom: 1px solid var(--main-dark-highlight);
 }
 
 ts-rocket>div>.checklist li::before {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }
 
 ts-rocket>div>.checklist li.checked {
@@ -9259,13 +9268,13 @@ ts-rocket a {
 }
 
 ts-rocket a caret::before {
-  background-color: #363636;
-  border-color: #363636;
+  background-color: var(--main-dark-highlight);
+  border-color: var(--main-dark-highlight);
 }
 
 ts-rocket caret::before {
-  background-color: #363636;
-  border: 1px solid #363636;
+  background-color: var(--main-dark-highlight);
+  border: 1px solid var(--main-dark-highlight);
 }
 
 ts-rocket carriage {
@@ -9277,7 +9286,7 @@ ts-rocket code, ts-rocket .pre.text, ts-rocket>div>pre {
 }
 
 ts-rocket hr {
-  border-color: #363636;
+  border-color: var(--main-dark-highlight);
 }
 
 ts-rocket ime {
@@ -9293,17 +9302,17 @@ ts-rocket selection::after, ts-rocket selection::before {
 }
 
 ts-space a.feedback {
-  color: #e6e6e6;
+  color: var(--main-text);
   text-shadow: -1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000, 1px -1px 0 #000;
 }
 
 ts-space a.feedback:hover {
-  background-color: #363636;
-  color: #e6e6e6;
+  background-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 ts-space header .divider {
-  border-top: 1px solid #545454;
+  border-top: 1px solid var(--main-highlight);
 }
 
 ts-space header .owner_detail ::selection, ts-space header .owner_detail ::-moz-selection {
@@ -9311,7 +9320,7 @@ ts-space header .owner_detail ::selection, ts-space header .owner_detail ::-moz-
 }
 
 ts-space header .owner_detail .file_title_header, ts-space header .owner_detail .inline-edit {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 ts-space header .owner_detail .inline-edit {
@@ -9319,11 +9328,11 @@ ts-space header .owner_detail .inline-edit {
 }
 
 ts-space header .owner_detail .inline-edit::-moz-placeholder {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 ts-space header .owner_detail .inline-edit::-webkit-input-placeholder {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 ts-space header .owner_detail .inline-edit:focus::-moz-placeholder {
@@ -9343,7 +9352,7 @@ ts-space header {
 }
 
 ts-thread .collapse_inline_thread_container:hover, ts-thread .view_all_replies_container:hover {
-  background-color: #222222;
+  background-color: var(--main-bg-color);
 }
 
 ts-thread .new_reply_indicator .blue_dot {
@@ -9351,13 +9360,13 @@ ts-thread .new_reply_indicator .blue_dot {
 }
 
 ts-thread .reply_input_container .collapsed_input_placeholder, ts-thread .reply_input_container .join_channel_from_thread_container, ts-thread .reply_input_container .reply_limited_in_general {
-  background: #363636;
-  border-color: #363636;
+  background: var(--main-dark-highlight);
+  border-color: var(--main-dark-highlight);
 }
 
 ts-thread .reply_input_container .inline_message_input_container form textarea {
-  border-color: #363636;
-  color: #e6e6e6;
+  border-color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 ts-thread .thread_header .thread_action_btns button {
@@ -9365,20 +9374,20 @@ ts-thread .thread_header .thread_action_btns button {
 }
 
 ts-thread .thread_header .thread_channel_name a {
-  color: #e6e6e6;
+  color: var(--main-text);
 }
 
 ts-thread .thread_messages {
-  background: #363636;
-  border-color: #363636;
+  background: var(--main-dark-highlight);
+  border-color: var(--main-dark-highlight);
 }
 
 ts-thread {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .p-workspace {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 .p-classic_nav__model__title__info {
@@ -9394,23 +9403,23 @@ ts-thread {
 }
 
 .p-workspace__input .p-message_input_field {
-  background-color: #363636 !important;
+  background-color: var(--main-dark-highlight) !important;
 }
 
 footer.p-workspace__primary_view_footer {
-  background-color: #222;
+  background-color: var(--main-bg-color);
 }
 
 .p-unreads_view__header {
-  background: #222 !important;
+  background: var(--main-bg-color) !important;
 }
 
 .menu ul li a:not(.inline_menu_link) {color: #fff !important;}
 
 ts-thread ts-message.new_reply {
-  background: #222;
+  background: var(--main-bg-color);
 }
 
 ts-thread ts-message.new_reply:hover {
-  background: #363636;
+  background: var(--main-dark-highlight);
 }

--- a/dark-theme.css
+++ b/dark-theme.css
@@ -3,6 +3,7 @@
   --main-dark-highlight: #363636; /* Text input, dividers */
   --main-highlight: #545454; /* Message bar top (new messages), Currently selected chat, Nes messages line */
   --main-text: #e6e6e6; /* Main text in the chat windows */
+  --sidebar-bg-color: #222; /* Sidebar background color */
   --text-hover: #c7c7c7; /* Based on the usage should be link hover color */
 }
 
@@ -4060,6 +4061,14 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .p-channel_insights_activity_bar_container:hover {
   background-color: rgba(0, 0, 0, 0.05);
+}
+
+.p-workspace__sidebar {
+  background: var(--sidebar-bg-color) !important;
+}
+
+.p-channel_sidebar__static_list {
+  background: var(--sidebar-bg-color) !important;
 }
 
 .p-channel_sidebar .c-custom_scrollbar__thumb_vertical, .p-channel_sidebar .c-scrollbar__bar {
@@ -9388,6 +9397,10 @@ ts-thread {
 
 .p-workspace {
   background: var(--main-bg-color);
+}
+
+.p-classic_nav__team_header {
+  background: var(--sidebar-bg-color) !important;
 }
 
 .p-classic_nav__model__title__info {


### PR DESCRIPTION
Introduce CSS properties which combine re-used colors to allow simple theming.

## Description

At the moment the css has a huge set of colors and many colors are used > 100 times. 
With this PR I added some general purpose CSS properties to replace those colors and allow them to be adjusted at a single location. 
It would be great if we could introduce a few additional properties to simplify for example coloring of the sidebar. (At the moment sidebar and messaging area have the same color)
(added new property for the sidebar background color)
This also fixes the wrong background color being used for the auto-suggestion dialog when searching for people to mention

## Related Issue
- none as far as I could find

## Motivation and Context
- I personally modified the colors as the original theme is not really my preference.
- Just for your interest. these are the values I use
```css
  --main-bg-color: #282A36; /* General background */
  --main-dark-highlight: #141622; /* Text input, dividers */
  --main-highlight: #151724; /* Message bar top (new messages), Currently selected chat, Nes messages line */
```

## How Has This Been Tested?
- applied on the Slack client v4.0.0 
- no difference to the original as I simply replaced the RGB values with the matching property replacing it

## Screenshots (if appropriate):
- it looks the same

## Types of changes
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document. (I haven't found it :D)
