### PR TITLE
Fix #114 author text color when doing a quote

### DIFF
--- a/dark-theme.css
+++ b/dark-theme.css
@@ -1078,7 +1078,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-message_attachment__author_name {
-  color: #f8f8f8;
+  color: #f8f8f8 !important;
 }
 
 .c-message_attachment__border {


### PR DESCRIPTION
## Description
* fix the author name when quoteing
  * FIX https://github.com/LanikSJ/slack-dark-mode/issues/114

## Related Issue
- https://github.com/LanikSJ/slack-dark-mode/issues/114

## Motivation and Context
- the linked github issue gets fixed

## How Has This Been Tested?
- applied on the latest version of the slack mac app

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
