### PR TITLE
Fix offline username text color | Fix "you" text color in title bar

### DIFF
--- a/dark-theme.css
+++ b/dark-theme.css
@@ -3,7 +3,7 @@
   --main-dark-highlight: #363636; /* Text input, dividers */
   --main-highlight: #545454; /* Message bar top (new messages), Currently selected chat, Nes messages line */
   --main-text: #e6e6e6; /* Main text in the chat windows */
-  --secondary-text: #B3e6e6e6; /* Secondary text (70% of main text) */
+  --secondary-text: #e6e6e6B3; /* Secondary text (70% of main text) */
   --sidebar-bg-color: #222; /* Sidebar background color */
   --text-hover: #c7c7c7; /* Based on the usage should be link hover color */
   --highlight-and-warnings: #bf360c; /* General hightlighs and warnings (important and new stuff) */

--- a/dark-theme.css
+++ b/dark-theme.css
@@ -3,6 +3,7 @@
   --main-dark-highlight: #363636; /* Text input, dividers */
   --main-highlight: #545454; /* Message bar top (new messages), Currently selected chat, Nes messages line */
   --main-text: #e6e6e6; /* Main text in the chat windows */
+  --secondary-text: #B3e6e6e6; /* Secondary text (70% of main text) */
   --sidebar-bg-color: #222; /* Sidebar background color */
   --text-hover: #c7c7c7; /* Based on the usage should be link hover color */
   --highlight-and-warnings: #bf360c; /* General hightlighs and warnings (important and new stuff) */
@@ -9412,6 +9413,18 @@ ts-thread {
 
 .p-classic_nav__model__title__info {
   color: rgba(230, 230, 230, .7);
+}
+
+.p-classic_nav__model__title__is_you {
+  color: var(--secondary-text);
+}
+
+.p-classic_nav__model__title__name--dim {
+  color: var(--secondary-text);
+}
+
+.p-classic_nav__model__title__name__status--im {
+  color: var(--secondary-text);
 }
 
 .p-classic_nav__right__search__placeholder {


### PR DESCRIPTION
## Description
* introduce new secondary text color --> it's 70% of the primary text
* fix offline user names in title
* fix "you" (if opening the chat window to yourself) and IM text

## Related Issue
- no open issue available

## Motivation and Context
- Seeing this bug in Slack 4.0.1 on Mac and wanted to fix it for everybody

## How Has This Been Tested?
- applied changes in Slack 4.0.1 using the install script

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1476232/62451088-de46a200-b76d-11e9-907a-68b10adf0c58.png)

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
