### PR TITLE
Fix the team quota text color

### DIFF
--- a/dark-theme.css
+++ b/dark-theme.css
@@ -4570,6 +4570,10 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
   color: var(--main-text);
 }
 
+.p-threads_flexpane__separator_count {
+  color: var(--main-text);
+}
+
 .p-threads_footer__input .p-message_input_field, .p-threads_footer__input--legacy .p-message_input_field {
   background: var(--main-dark-highlight);
 }

--- a/dark-theme.css
+++ b/dark-theme.css
@@ -9487,6 +9487,10 @@ ts-thread {
   background: var(--sidebar-bg-color) !important;
 }
 
+.p-classic_nav__team_messages_progress_bar_text {
+  fill: var(--main-text) !important;
+}
+
 .p-classic_nav__team_menu__blurb__name {
   color: var(--main-text);
 }


### PR DESCRIPTION
## Description
* fix the text color of the progress bar for the team quota

## Related Issue
- https://github.com/LanikSJ/slack-dark-mode/issues/125

## Motivation and Context
- fix reported issue

## How Has This Been Tested?
- slack on mac 4.0.1

## Screenshots (if appropriate):

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
