### PR TITLE
Fix text colors in create/browse channel screen, dm screen

### DIFF
--- a/dark-theme.css
+++ b/dark-theme.css
@@ -1459,7 +1459,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-select_button__content {
-  color: var(--main-dark-highlight);
+  color: var(--main-text);
 }
 
 .c-tabs__tab {
@@ -4001,6 +4001,22 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
   background: var(--main-dark-highlight);
   border-color: var(--main-highlight);
   color: var(--main-text);
+}
+
+.p-dm_browser_modal__list_heading{
+  color: var(--main-text);
+}
+
+.p-dm_browser_modal__list_row_meta {
+  color: var(--main-text);
+}
+
+.p-channel_browser_section_header {
+  color: var(--main-text);
+}
+
+.p-channel_browser_list_item__create_info {
+  color: var(--secondary-text);
 }
 
 .p-channel_insights .c-member__title {

--- a/dark-theme.css
+++ b/dark-theme.css
@@ -725,7 +725,7 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .c-hint {
-  color: #f8f8f8;
+  color: var(--secondary-text);
 }
 
 .c-icon {
@@ -6856,6 +6856,50 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 #details_tab .created_by {
   color: var(--main-text);
+}
+
+.p-channel_name_input__label_title strong {
+  color: var(--main-text);
+}
+
+.p-channel_name_input__label_title  {
+  color: var(--secondary-text);
+}
+
+.p-channel_create_modal__label_title strong {
+  color: var(--main-text);
+}
+
+.p-channel_create_modal__label_title {
+  color: var(--secondary-text);
+}
+
+.p-channel_create_modal__input_subtext {
+  color: var(--secondary-text);
+}
+
+.p-invite_users_input__label_title strong {
+  color: var(--main-text);
+}
+
+.p-invite_users_input__label_title {
+  color: var(--secondary-text);
+}
+
+.p-invite_users_input__input_subtext {
+  color: var(--secondary-text);
+}
+
+.p-channel_create_modal__sub_section_copy_title strong {
+  color: var(--main-text);
+}
+
+.p-channel_create_modal__sub_section_copy_title {
+  color: var(--secondary-text);
+}
+
+.p-channel_create_modal__sub_section_copy_body {
+  color: var(--secondary-text);
 }
 
 #details_tab .feature_sli_channel_insights .channel_created_section .creator_link, #details_tab .feature_sli_channel_insights .channel_purpose_section .channel_purpose_text {


### PR DESCRIPTION
## Description
* properly set color for all the labels in the create channel screen
* also fix the colors for brows and direct messages

## Related Issue
- Fixes https://github.com/LanikSJ/slack-dark-mode/issues/133

## Motivation and Context
- fix reported issue

## How Has This Been Tested?
Slack 4.0.1 on Mac

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
