### PR TITLE
adding new snap script

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - snap-slack-dark-mode.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ before_install:
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" ; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update && brew cask install slack ; fi
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo snap install slack --classic ; fi
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then brew update ; fi
 - touch custom-dark-theme.css
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
 
 script:
 - sudo kcov coverage slack-dark-mode.sh
+- sudo kcov coverage snap-slack-dark-mode.sh
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_install:
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" ; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update && brew cask install slack ; fi
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo snap install slack --classic ; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash - ; fi
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install nodejs ; fi
 - touch custom-dark-theme.css
 
@@ -43,7 +44,7 @@ install:
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s ${HOME}/kcov/bin/kcov /usr/bin/kcov ; fi
 
 script:
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo kcov coverage slack-dark-mode.sh; fi
+# - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo kcov coverage slack-dark-mode.sh; fi
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo kcov coverage snap-slack-dark-mode.sh; fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ matrix:
       rvm: system
     - os: linux
       dist: bionic
-      language: node_js
   fast_finish: true
 
 env:
@@ -34,6 +33,7 @@ before_install:
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" ; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update && brew cask install slack ; fi
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo snap install slack --classic ; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install nodejs ; fi
 - touch custom-dark-theme.css
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ before_install:
 - wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz
 - /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 - brew update && brew cask install slack
+- brew install snapcraft
+- sudo snap install slack --classic
 - touch custom-dark-theme.css
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ matrix:
     - os: osx
       osx_image: xcode10
       rvm: system
-    - os: linux
-      dist: xenial
   fast_finish: true
 
 env:
@@ -30,22 +28,17 @@ env:
 
 before_install:
 - wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; then /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" ; fi
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update && brew cask install slack ; fi
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo snap install slack --classic ; fi
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash - ; fi
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install nodejs ; fi
+- /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+- brew update && brew cask install slack
 - touch custom-dark-theme.css
 
 install:
 - tar xzf master.tar.gz && cd kcov-master && mkdir build && cd build
 - cmake -DCMAKE_INSTALL_PREFIX=${HOME}/kcov .. && make && sudo make install
 - cd ../.. && rm -rf kcov-master && mkdir -p coverage
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s ${HOME}/kcov/bin/kcov /usr/bin/kcov ; fi
 
 script:
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo kcov coverage slack-dark-mode.sh; fi
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo kcov coverage snap-slack-dark-mode.sh; fi
+- sudo kcov coverage slack-dark-mode.sh
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
       rvm: system
     - os: linux
       dist: bionic
+      language: node_js
   fast_finish: true
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
       osx_image: xcode10
       rvm: system
     - os: linux
-      dist: bionic
+      dist: xenial
   fast_finish: true
 
 env:
@@ -44,7 +44,7 @@ install:
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s ${HOME}/kcov/bin/kcov /usr/bin/kcov ; fi
 
 script:
-# - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo kcov coverage slack-dark-mode.sh; fi
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo kcov coverage slack-dark-mode.sh; fi
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo kcov coverage snap-slack-dark-mode.sh; fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
 - tar xzf master.tar.gz && cd kcov-master && mkdir build && cd build
 - cmake -DCMAKE_INSTALL_PREFIX=${HOME}/kcov .. && make && sudo make install
 - cd ../.. && rm -rf kcov-master && mkdir -p coverage
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s ${HOME}/kcov/bin/kcov /usr/bin/kcov ; fi
 
 script:
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo kcov coverage slack-dark-mode.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
     - os: osx
       osx_image: xcode10
       rvm: system
+    - os: linux
+      dist: bionic
   fast_finish: true
 
 env:
@@ -28,10 +30,10 @@ env:
 
 before_install:
 - wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz
-- /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-- brew update && brew cask install slack
-- brew install snapcraft
-- sudo snap install slack --classic
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" ; fi
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update && brew cask install slack ; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo snap install slack --classic ; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then brew update ; fi
 - touch custom-dark-theme.css
 
 install:
@@ -40,8 +42,8 @@ install:
 - cd ../.. && rm -rf kcov-master && mkdir -p coverage
 
 script:
-- sudo kcov coverage slack-dark-mode.sh
-- sudo kcov coverage snap-slack-dark-mode.sh
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo kcov coverage slack-dark-mode.sh; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo kcov coverage snap-slack-dark-mode.sh; fi
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ git clone https://github.com/LanikSJ/slack-dark-mode && cd slack-dark-mode \
 For SNAP users: Since snap is a 'read-only' file system, we have to mount the changes.\
 The script automatically insert a new crontab so it will persist through reboots.\
 Since the way SNAPS work are different, we can easily revert to light mode as well with the script.
-```
+```bash
 ./snap-slack-dark-mode.sh [-u] [-light]
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![Known Vulnerabilities](https://snyk.io/test/github/laniksj/slack-dark-mode/badge.svg?targetFile=/docs/Gemfile.lock)](https://snyk.io/test/github/laniksj/slack-dark-mode?targetFile=/docs/Gemfile.lock)
 
 ## Purpose
-Store scripts and Style sheets for Slack Dark Mode for macOS Mojave.  
+Store scripts and Style sheets for Slack Dark Mode for macOS Mojave.\
 Dark Mode in Slack isn't available as of this writing.
 
 ## Notice
-Due to the changes in Slack 4.0+ this project will not be compatible with Slack Version 3.4 or below.  
+Due to the changes in Slack 4.0+ this project will not be compatible with Slack Version 3.4 or below.\
 If you're looking for 3.4.x compatible settings please refer to [this](https://github.com/LanikSJ/slack-dark-mode/tree/466ff22d5b606b6d5b2edeff54f4cd7a3bafc39c).
 
 ## Usage
@@ -29,6 +29,14 @@ $ git clone https://github.com/LanikSJ/slack-dark-mode && cd slack-dark-mode \
 && osascript -e 'tell application "Slack" to quit' \
 && killall Slack && sleep 60 && open -a "/Applications/Slack.app"
 ````
+
+For SNAP users: Since snap is a 'read-only' file system, we have to mount the changes.\
+The script automatically insert a new crontab so it will persist through reboots.\
+Since the way SNAPS work are different, we can easily revert to light mode as well with the script.
+```
+./snap-slack-dark-mode.sh [-u] [-light]
+```
+
 For Windows Users:
 ```powershell
 PS ~/> git clone https://github.com/LanikSJ/slack-dark-mode
@@ -40,14 +48,13 @@ PS ~/> git clone https://github.com/LanikSJ/slack-dark-mode
 PS ~/> cd slack-dark-mode; .\slack-dark-mode.ps1 -UpdateOnly
 ```
 
-You can tweak your own css colors by creating a new file called `custom-dark-theme.css`,    
-which will be used to overwrite the current theme.
+You can tweak your own css colors by creating a new file called `custom-dark-theme.css`, which will be used to overwrite the current theme.
 
 ## Screenshot
 ![Screenshot](https://github.com/LanikSJ/slack-dark-mode/raw/master/images/screenshot.png "Screenshot")
 
 ## Attributions
-Some scripts were "borrowed" from [mmrko](https://gist.github.com/mmrko) [Gist](https://gist.github.com/mmrko/9b0e65f6bcc1fca57089c32c2228aa39)  
+Some scripts were "borrowed" from [mmrko](https://gist.github.com/mmrko) [Gist](https://gist.github.com/mmrko/9b0e65f6bcc1fca57089c32c2228aa39)\
 ©️ All rights reserved by the original authors.
 
 ## Bugs

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ $ git clone https://github.com/LanikSJ/slack-dark-mode && cd slack-dark-mode \
 ````
 For SNAP users: Since snap is a 'read-only' file system, we have to mount the changes. The script automatically insert a new crontab so it will persist through reboots.\
 Since the way SNAPS work are different, we can easily revert to light mode as well with the script.
-```
+```bash
 ./snap-slack-dark-mode.sh [-u] [-light]
 ```
 For Windows Users:

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,14 +9,14 @@ title: Slack Dark Mode
 Purpose
 ============
 
-Store scripts and Style sheets for Slack Dark Mode for macOS Mojave.  
+Store scripts and Style sheets for Slack Dark Mode for macOS Mojave.\
 Dark Mode in Slack isn't available as of this writing.
 
 Notice
 ============
 
-Due to the changes in Slack 4.0+ this project will not be compatible with Slack Version 3.4 or below.   
-If you're looking for 3.4.x compatible settings please refer to [this](https://github.com/LanikSJ/slack-dark-mode/tree/466ff22d5b606b6d5b2edeff54f4cd7a3bafc39c).   
+Due to the changes in Slack 4.0+ this project will not be compatible with Slack Version 3.4 or below.\
+If you're looking for 3.4.x compatible settings please refer to [this](https://github.com/LanikSJ/slack-dark-mode/tree/466ff22d5b606b6d5b2edeff54f4cd7a3bafc39c).
 
 Usage
 ============
@@ -35,6 +35,11 @@ $ git clone https://github.com/LanikSJ/slack-dark-mode && cd slack-dark-mode \
 && osascript -e 'tell application "Slack" to quit' \
 && killall Slack && sleep 60 && open -a "/Applications/Slack.app"
 ````
+For SNAP users: Since snap is a 'read-only' file system, we have to mount the changes. The script automatically insert a new crontab so it will persist through reboots.\
+Since the way SNAPS work are different, we can easily revert to light mode as well with the script.
+```
+./snap-slack-dark-mode.sh [-u] [-light]
+```
 For Windows Users:
 ```powershell
 PS ~/> git clone https://github.com/LanikSJ/slack-dark-mode
@@ -55,8 +60,8 @@ Screenshot
 Attributions
 ============
 
-Scripts was "borrowed" from [mmrko](https://gist.github.com/mmrko) [Gist](https://gist.github.com/mmrko/9b0e65f6bcc1fca57089c32c2228aa39)  
-All rights reserved by the original authors.  
+Scripts was "borrowed" from [mmrko](https://gist.github.com/mmrko) [Gist](https://gist.github.com/mmrko/9b0e65f6bcc1fca57089c32c2228aa39)\
+©️ All rights reserved by the original authors.
 
 Bugs
 ============

--- a/snap-slack-dark-mode.sh
+++ b/snap-slack-dark-mode.sh
@@ -58,7 +58,7 @@ if [[ "$UPDATE_ONLY" == "false" ]]; then
     sudo npx asar extract $SLACK_RESOURCES_DIR/app.asar $ssb_js_dir/app.asar.unpacked
 
     # Add JS Code to Slack
-    sudo tee -a "$SLACK_FILEPATH" < $SLACK_EVENT_LISTENER
+    cat $SLACK_EVENT_LISTENER | sudo tee -a "$SLACK_FILEPATH"
 
     # Insert the CSS File Location in JS
     sudo sed -i -e s@SLACK_DARK_THEME_PATH@$THEME_FILEPATH@g $SLACK_FILEPATH

--- a/snap-slack-dark-mode.sh
+++ b/snap-slack-dark-mode.sh
@@ -50,7 +50,7 @@ sudo cp -af dark-theme.css "$THEME_FILEPATH"
 # if we have a custom file, append to the end.
 if [[ -f custom-dark-theme.css ]]; then
     echo "Adding custom css"
-    sudo cat custom-dark-theme.css >> "$THEME_FILEPATH"
+    cat custom-dark-theme.css >> "$THEME_FILEPATH"
 fi
 
 if [[ "$UPDATE_ONLY" == "false" ]]; then
@@ -72,11 +72,11 @@ if [[ "$UPDATE_ONLY" == "false" ]]; then
     if ! [[ $isTabbed ]]; then
         echo "Installing new crontab to apply on reboot..."
         # Save current crontab
-        sudo crontab -l > tab.tmp
+        sudo crontab -l | sudo tee tab.tmp
         # Add new tab
         echo "@reboot sudo mount --bind -o nodev,ro /opt/slack-dark/app.asar /snap/slack/current/usr/lib/slack/resources/app.asar" >> tab.tmp
         # replace crontab
         sudo crontab tab.tmp
-        rm tab.tmp
+        sudo rm tab.tmp
     fi
 fi

--- a/snap-slack-dark-mode.sh
+++ b/snap-slack-dark-mode.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Usage: ./snap-slack-dark-mode.sh
+#   [-u] for update only.
+#   [-light] to revert to light mode.
+
+SLACK_RESOURCES_DIR="/snap/slack/current/usr/lib/slack/resources"
+ssb_js_dir="/opt/slack-dark" # directory where to place our adjusted js file.
+UPDATE_ONLY="false"
+
+if ! [[ -d $SLACK_RESOURCES_DIR ]]; then echo "You do not have snap version of slack installed."; exit; fi
+
+
+for arg in "$@"; do
+    shift
+    case "$arg" in
+        -u) UPDATE_ONLY="true" ;;
+        -light)
+            echo "Removing Dark mode"
+            sudo killall slack 2>/dev/null
+            sudo umount /snap/slack/current/usr/lib/slack/resources/app.asar
+            exit
+            ;;
+        *) echo "Option doesn't exist"; exit 1 ;;
+    esac
+done
+
+echo && echo "This script requires sudo privileges." && echo "You'll need to provide your password."
+
+type npx
+if [[ "$?" != "0" ]]; then echo "Please install Node"; exit; fi
+
+# ensure we don't have the mount already
+sudo umount /snap/slack/current/usr/lib/slack/resources/app.asar 2>/dev/null
+
+# make sure we have a directory to mount the adjusted file from.
+sudo mkdir -p "$ssb_js_dir/app.asar.unpacked/dist/"
+
+SLACK_EVENT_LISTENER="event-listener.js"
+SLACK_FILEPATH="$ssb_js_dir/app.asar.unpacked/dist/ssb-interop.bundle.js"
+THEME_FILEPATH="$ssb_js_dir/dark-theme.css"
+
+case "$UPDATE_ONLY" in
+    "true") echo && echo "Updating Dark Theme Code for Slack... " ;;
+    "false") echo && echo "Adding Dark Theme Code to Slack... "  ;;
+esac
+
+# Copy CSS to Slack Folder
+sudo cp -af dark-theme.css "$THEME_FILEPATH"
+
+# if we have a custom file, append to the end.
+if [[ -f custom-dark-theme.css ]]; then
+    echo "Adding custom css"
+    sudo cat custom-dark-theme.css >> "$THEME_FILEPATH"
+fi
+
+if [[ "$UPDATE_ONLY" == "false" ]]; then
+    # Unpack Asar Archive for Slack
+    sudo npx asar extract $SLACK_RESOURCES_DIR/app.asar $ssb_js_dir/app.asar.unpacked
+
+    # Add JS Code to Slack
+    sudo tee -a "$SLACK_FILEPATH" < $SLACK_EVENT_LISTENER
+
+    # Insert the CSS File Location in JS
+    sudo sed -i -e s@SLACK_DARK_THEME_PATH@$THEME_FILEPATH@g $SLACK_FILEPATH
+
+    # Pack the Asar Archive for Slack
+    sudo npx asar pack $ssb_js_dir/app.asar.unpacked $ssb_js_dir/app.asar
+
+    sudo mount --bind -o nodev,ro $ssb_js_dir/app.asar $SLACK_RESOURCES_DIR/app.asar
+
+    isTabbed=$(sudo crontab -l | grep $ssb_js_dir/app.asar)
+    if ! [[ $isTabbed ]]; then
+        echo "Installing new crontab to apply on reboot..."
+        # Save current crontab
+        sudo crontab -l > tab.tmp
+        # Add new tab
+        echo "@reboot sudo mount --bind -o nodev,ro /opt/slack-dark/app.asar /snap/slack/current/usr/lib/slack/resources/app.asar" >> tab.tmp
+        # replace crontab
+        sudo crontab tab.tmp
+        rm tab.tmp
+    fi
+fi


### PR DESCRIPTION
## Description
Snap installs are read-only so its difficult to make dark mode changes
This script will do most of the same changes and setup as the main script, but will mount the files from a special `/opt` directory.

## Motivation and Context
Some people use SNAP to install their applications, but since snap is a read-only filesystem, i had some troubles figuring out how to get dark mode working after 4.0 hit.

## How Has This Been Tested?
This has been tested on my Ubuntu 19.04 linux install.

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist:
-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
