### PR TITLE
Pull from repo instead of web in windows script

### DIFF
--- a/slack-dark-mode.ps1
+++ b/slack-dark-mode.ps1
@@ -43,7 +43,7 @@ if (-not (Test-Path -Path $themeFile)) {
 }
 
 Write-Output "Fetching Theme from $CSSUrl"
-Invoke-WebRequest -UseBasicParsing -Method GET -Uri $CSSUrl | Select-Object -ExpandProperty Content | Set-Content -Path $themeFile
+cat ./dark-theme.css | Set-Content -Path $themeFile # add the theme from the repo
 
 if (Test-Path ./custom-dark-theme.css) {
     cat ./custom-dark-theme.css | Add-Content $themeFile


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
pull css from the repo instead of web, which allows easier testing in windows and doesn't require an extra webrequest to prevent misc errors.

## Related Issue
#150 

## Motivation and Context
See #150 

## How Has This Been Tested?
Testing using Windows, on slack 4.01, i was able to revert back to light mode and then run the script to see that it worked.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)
