### PR TITLE
Light mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,17 +38,11 @@ install:
 - cd ../.. && rm -rf kcov-master && mkdir -p coverage
 - mkdir -p coverage-light
 
-jobs:
-  allow_failures:
-    - script: sudo kcov coverage-not-option slack-dark-mode.sh -not-an-option
-
 script:
 - sudo kcov coverage slack-dark-mode.sh
 - sudo kcov coverage-light slack-dark-mode.sh --light
 - sudo kcov coverage-update slack-dark-mode.sh -u
 
 after_success:
-- echo ""
-
-after_script:
-  - bash <(curl -s https://codecov.io/bash)
+- sudo kcov coverage-not-option slack-dark-mode.sh -not-an-option
+- bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ install:
 script:
 - sudo kcov coverage slack-dark-mode.sh
 - sudo kcov coverage-light slack-dark-mode.sh --light
+- sudo kcov coverage-update slack-dark-mode.sh -u
+- sudo kcov coverage-update slack-dark-mode.sh -not-an-option
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
 - sudo kcov coverage slack-dark-mode.sh
 - sudo kcov coverage-light slack-dark-mode.sh --light
 - sudo kcov coverage-update slack-dark-mode.sh -u
-- sudo kcov coverage-update slack-dark-mode.sh -not-an-option
+- sudo kcov coverage-not-option slack-dark-mode.sh -not-an-option
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,11 @@ install:
 - tar xzf master.tar.gz && cd kcov-master && mkdir build && cd build
 - cmake -DCMAKE_INSTALL_PREFIX=${HOME}/kcov .. && make && sudo make install
 - cd ../.. && rm -rf kcov-master && mkdir -p coverage
+- mkdir -p coverage-light
 
 script:
 - sudo kcov coverage slack-dark-mode.sh
-- sudo kcov coverage slack-dark-mode.sh --light
+- sudo kcov coverage-light slack-dark-mode.sh --light
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
 
 script:
 - sudo kcov coverage slack-dark-mode.sh
+- sudo kcov coverage slack-dark-mode.sh --light
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,17 @@ install:
 - cd ../.. && rm -rf kcov-master && mkdir -p coverage
 - mkdir -p coverage-light
 
+jobs:
+  allow_failures:
+    - script: sudo kcov coverage-not-option slack-dark-mode.sh -not-an-option
+
 script:
 - sudo kcov coverage slack-dark-mode.sh
 - sudo kcov coverage-light slack-dark-mode.sh --light
 - sudo kcov coverage-update slack-dark-mode.sh -u
-- sudo kcov coverage-not-option slack-dark-mode.sh -not-an-option
 
 after_success:
-- bash <(curl -s https://codecov.io/bash)
+- echo ""
+
+after_script:
+  - bash <(curl -s https://codecov.io/bash)

--- a/slack-dark-mode.ps1
+++ b/slack-dark-mode.ps1
@@ -50,7 +50,7 @@ if (-not (Test-Path -Path $themeFile)) {
 }
 
 Write-Output "Fetching Theme from $CSSUrl"
-cat ./dark-theme.css | Set-Content -Path $themeFile # add the theme from the repo
+Get-Content ./dark-theme.css | Set-Content -Path $themeFile # add the theme from the repo
 
 if (Test-Path ./custom-dark-theme.css) {
     Get-Content ./custom-dark-theme.css | Add-Content $themeFile

--- a/slack-dark-mode.ps1
+++ b/slack-dark-mode.ps1
@@ -3,7 +3,8 @@
 Param(
     [string] $CSSUrl = "https://raw.githubusercontent.com/LanikSJ/slack-dark-mode/master/dark-theme.css",
     [string] $SlackBase = $null,
-    [switch] $UpdateOnly
+    [switch] $UpdateOnly,
+    [switch] $LightMode
 )
 
 if (-not (Get-Command -Name "npx" -ErrorAction SilentlyContinue)) {
@@ -34,6 +35,12 @@ if ([string]::IsNullOrWhiteSpace($SlackBase)) {
 $resources = Join-Path -Path $latestPath -ChildPath "resources"
 $themeFile = Join-Path -Path $resources -ChildPath "custom_theme.css"
 
+if ($LightMode -eq $true) {
+    Write-Output "Removing Dark Theme.."
+    Remove-Item $themeFile
+    exit
+}
+
 Write-Output "Stopping Slack"
 Get-Process *slack* | Stop-Process -Force
 
@@ -46,7 +53,7 @@ Write-Output "Fetching Theme from $CSSUrl"
 cat ./dark-theme.css | Set-Content -Path $themeFile # add the theme from the repo
 
 if (Test-Path ./custom-dark-theme.css) {
-    cat ./custom-dark-theme.css | Add-Content $themeFile
+    Get-Content ./custom-dark-theme.css | Add-Content $themeFile
 }
 
 if (-not $UpdateOnly) {

--- a/slack-dark-mode.ps1
+++ b/slack-dark-mode.ps1
@@ -37,6 +37,7 @@ $themeFile = Join-Path -Path $resources -ChildPath "custom_theme.css"
 
 if ($LightMode -eq $true) {
     Write-Output "Removing Dark Theme.."
+    Write-Output "Please refresh Slack (ctrl + R)"
     Remove-Item $themeFile
     exit
 }

--- a/slack-dark-mode.ps1
+++ b/slack-dark-mode.ps1
@@ -38,7 +38,7 @@ $themeFile = Join-Path -Path $resources -ChildPath "custom_theme.css"
 if ($LightMode -eq $true) {
     Write-Output "Removing Dark Theme.."
     Write-Output "Please refresh Slack (ctrl + R)"
-    Remove-Item $themeFile
+    Remove-Item $themeFile -Force
     exit
 }
 

--- a/slack-dark-mode.sh
+++ b/slack-dark-mode.sh
@@ -7,7 +7,15 @@ SLACK_DIRECT_LOCAL_SETTINGS="Library/Application\ Support/Slack/local-settings.j
 SLACK_STORE_LOCAL_SETTINGS="Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Application\ Support/Slack/local-settings.json"
 OSX_SLACK_RESOURCES_DIR="/Applications/Slack.app/Contents/Resources"
 LINUX_SLACK_RESOURCES_DIR="/usr/lib/slack/resources"
-UPDATE_ONLY="false"
+
+for arg in "$@"; do
+    shift
+    case "$arg" in
+        -u) UPDATE_ONLY="true" ;;
+        -light) LIGHT_MODE="true"
+        *) echo "Option doesn't exist"; exit 1 ;;
+    esac
+done
 
 echo && echo "This script requires sudo privileges." && echo "You'll need to provide your password."
 
@@ -35,6 +43,13 @@ if [[ "$UPDATE_ONLY" == "false" ]]; then
 fi
 
 if [[ -z $HOME ]]; then HOME=$(ls -d ~); fi
+
+if [[ "$LIGHT_MODE" == "true" ]]; then
+    echo "Removing Dark Theme.."
+    echo "Please refresh slack (ctrl/cmd + R)"
+    sudo rm $THEME_FILEPATH
+    exit
+fi
 
 # Copy CSS to Slack Folder
 sudo cp -af dark-theme.css "$THEME_FILEPATH"

--- a/slack-dark-mode.sh
+++ b/slack-dark-mode.sh
@@ -47,7 +47,7 @@ if [[ -z $HOME ]]; then HOME=$(ls -d ~); fi
 if [[ "$LIGHT_MODE" == "true" ]]; then
     echo "Removing Dark Theme.."
     echo "Please refresh slack (ctrl/cmd + R)"
-    sudo rm $THEME_FILEPATH
+    sudo rm -f $THEME_FILEPATH
     exit
 fi
 

--- a/slack-dark-mode.sh
+++ b/slack-dark-mode.sh
@@ -18,8 +18,6 @@ for arg in "$@"; do
     esac
 done
 
-exit
-
 echo && echo "This script requires sudo privileges." && echo "You'll need to provide your password."
 
 type npx

--- a/slack-dark-mode.sh
+++ b/slack-dark-mode.sh
@@ -7,12 +7,13 @@ SLACK_DIRECT_LOCAL_SETTINGS="Library/Application\ Support/Slack/local-settings.j
 SLACK_STORE_LOCAL_SETTINGS="Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Application\ Support/Slack/local-settings.json"
 OSX_SLACK_RESOURCES_DIR="/Applications/Slack.app/Contents/Resources"
 LINUX_SLACK_RESOURCES_DIR="/usr/lib/slack/resources"
+UPDATE_ONLY="false"
 
 for arg in "$@"; do
     shift
     case "$arg" in
         -u) UPDATE_ONLY="true" ;;
-        -light) LIGHT_MODE="true"
+        -light) LIGHT_MODE="true" ;;
         *) echo "Option doesn't exist"; exit 1 ;;
     esac
 done

--- a/slack-dark-mode.sh
+++ b/slack-dark-mode.sh
@@ -12,11 +12,13 @@ UPDATE_ONLY="false"
 for arg in "$@"; do
     shift
     case "$arg" in
-        -u) UPDATE_ONLY="true" ;;
-        -light) LIGHT_MODE="true" ;;
+        -[uU]|--[uU]pdate) UPDATE_ONLY="true" ;;
+        -[lL]|--[lL]ight) LIGHT_MODE="true" ;;
         *) echo "Option doesn't exist"; exit 1 ;;
     esac
 done
+
+exit
 
 echo && echo "This script requires sudo privileges." && echo "You'll need to provide your password."
 

--- a/snap-slack-dark-mode.sh
+++ b/snap-slack-dark-mode.sh
@@ -18,8 +18,8 @@ unmount_slack () {
 for arg in "$@"; do
     shift
     case "$arg" in
-        -u) UPDATE_ONLY="true" ;;
-        -light)
+        -[uU]|--[uU]pdate) UPDATE_ONLY="true" ;;
+        -[lL]|--[lL]ight)
             echo "Removing Dark mode"
             unmount_slack
             exit
@@ -57,7 +57,7 @@ fi
 if [[ "$UPDATE_ONLY" == "false" ]]; then
     # ensure we don't have the mount already
     unmount_slack
-    
+
     # Unpack Asar Archive for Slack
     sudo npx asar extract $SLACK_RESOURCES_DIR/app.asar $ssb_js_dir/app.asar.unpacked
 


### PR DESCRIPTION
## Description
Simply Deletes the CSS file to go back to light mode.  This also allows 'Update Only' to get Dark mode without having to extract/pack the asar.

## Related Issue
#111 

## Motivation and Context
Fixes #111 

## How Has This Been Tested?
Tested on windows and Ubuntu, need someone to test on Mac.

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)
