### PR TITLE
Fix SyntaxHighlighter Background | Bottom Message send background

### DIFF
--- a/dark-theme.css
+++ b/dark-theme.css
@@ -2008,8 +2008,12 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 }
 
 .CodeMirror {
-  background: #000;
+  background: var(--main-dark-highlight) !important;
   border: 1px solid var(--main-dark-highlight);
+  color: var(--main-text) !important;
+}
+
+.CodeMirror-code div::before {
   color: var(--main-text) !important;
 }
 

--- a/dark-theme.css
+++ b/dark-theme.css
@@ -9591,8 +9591,8 @@ ts-thread {
   background-color: var(--main-dark-highlight) !important;
 }
 
-footer.p-workspace__primary_view_footer {
-  background-color: var(--main-bg-color);
+.workspace__primary_view_footer {
+  background-color: var(--main-bg-color) !important;
 }
 
 .p-unreads_view__header {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* fix bottom bar for message input has wrong background (not input field, but around the area)
  * FIX https://github.com/LanikSJ/slack-dark-mode/issues/157
* fix shared code not properly themed …
  * FIX #162

## Related Issue
- https://github.com/LanikSJ/slack-dark-mode/issues/157
- https://github.com/LanikSJ/slack-dark-mode/issues/162

## Motivation and Context
- Fix reported issues

## How Has This Been Tested?
MacOS X, Slack 4.0.2

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
