### PR TITLE
Fix white channel preview pane

### DIFF
--- a/dark-theme.css
+++ b/dark-theme.css
@@ -9610,3 +9610,11 @@ ts-thread ts-message.new_reply {
 ts-thread ts-message.new_reply:hover {
   background: var(--main-dark-highlight);
 }
+
+.p-message_pane_input__preview {
+  background-color: var(--main-dark-highlight) !important;
+}
+
+.p-message_pane_input__preview div {
+  color: var(--main-text) !important;
+}


### PR DESCRIPTION
## Description
When previewing a channel the footer pane is still white with dark text. 

This fix changes it to fit the rest of the dark mode style.

Relevant screenshots below.

## Related Issue
Fixed [\#164](https://github.com/LanikSJ/slack-dark-mode/issues/163)

## Motivation and Context
- Fix the issue reported

## How Has This Been Tested?
Slack and Travis.

## Screenshots (if appropriate):
![Screen Shot 2019-08-22 at 11 45 03 AM](https://user-images.githubusercontent.com/15152269/63529917-8d57dd00-c4d3-11e9-8c08-a7f263877568.png)

![Screen Shot 2019-08-22 at 11 54 58 AM](https://user-images.githubusercontent.com/15152269/63530358-4dddc080-c4d4-11e9-8bbd-ec93a3ce1e39.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [X] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
