### PR TITLE
Fix light drop-down boxes

### DIFF
--- a/dark-theme.css
+++ b/dark-theme.css
@@ -9622,3 +9622,23 @@ ts-thread ts-message.new_reply:hover {
 .p-message_pane_input__preview div {
   color: var(--main-text) !important;
 }
+
+.c-select_button {
+  background-color: var(--main-dark-highlight) !important;
+}
+
+div[role=listbox] {
+  background-color: var(--main-dark-highlight) !important;
+}
+
+.c-select_options_list__option {
+  color: var(--main-text) !important;
+}
+
+.c-select_options_list__option--selected {
+  color: #3aa3e3 !important;
+}
+
+.c-select_options_list__option--active {
+  color: var(--main-text) !important;
+}


### PR DESCRIPTION
## Description
Fix light dropdown boxes in preferences menu. Change drop-down button and background to dark. Change drop-down text to light. 

## Related Issue
Fix: #156

## Motivation and Context
- Fix the issue reported

## How Has This Been Tested?
Slack & Travis.

## Screenshots (if appropriate):
<img width="756" alt="Screen Shot 2019-08-22 at 3 40 09 PM" src="https://user-images.githubusercontent.com/15152269/63544498-601b2700-c4f3-11e9-835b-5b4d0ab0137c.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [X] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
