### PR TITLE
 Bugfix: Light background color on names in Direct Message search list

### DIFF
--- a/dark-theme.css
+++ b/dark-theme.css
@@ -9642,3 +9642,7 @@ div[role=listbox] {
 .c-select_options_list__option--active {
   color: var(--main-text) !important;
 }
+
+.p-dm_browser_modal__list_row--active {
+  background-color: var(--main-dark-highlight) !important;
+}


### PR DESCRIPTION
## Description
Bugfix for issue where rows in DM had a light background, this fix makes it fit with the rest of the dark theme. Screenshot of new version is below.

## Related Issue
#147 

## Motivation and Context
Fixes issue #147 .

## How Has This Been Tested?
Slack and Travis.

## Screenshots (if appropriate):
<img width="670" alt="Screen Shot 2019-08-23 at 5 02 11 PM" src="https://user-images.githubusercontent.com/15152269/63623717-544d6480-c5c8-11e9-87be-a73063ba136f.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [X] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
