### PR TITLE
Colorize context bar

### DIFF
--- a/dark-theme.css
+++ b/dark-theme.css
@@ -4212,6 +4212,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
   color: #949494 !important;
 }
 
+.p-context_bar {
+  background: var(--main-bg-color);
+  color: var(--main-text);
+}
+
 .p-custom_status_input__clear_icon {
   color: #f8f8f8;
 }


### PR DESCRIPTION
Fixes a bug with unstyled context bar.

## Description
This PR makes context bar over message input dark.

## Related Issue
https://github.com/LanikSJ/slack-dark-mode/issues/179

## Motivation and Context
This makes private chat with a person in a different timezone look better. 

## How Has This Been Tested?
See screenshot.

## Screenshots (if appropriate):
![Screenshot 2019-08-26 at 11 35 43](https://user-images.githubusercontent.com/1500700/63677760-5d237d80-c7f6-11e9-9d79-cd99d4473703.png)

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
