### PR TITLE
Hotkey to Toggle Dark Mode

### DIFF
--- a/event-listener.js
+++ b/event-listener.js
@@ -1,3 +1,4 @@
+
 document.addEventListener('DOMContentLoaded', function() {
   const fs = require('fs');
   const filePath = "SLACK_DARK_THEME_PATH";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Uses `ctrl + L` to toggle dark mode on and off.  The change is instantaneous and no refresh or restart is required! It checks and sets a boolean using the localStorage API, so the toggle persists when the app is closed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Feature: #182 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There have been requests for a way to easily toggle dark and light mode, this also opens the opportunity to enable day/night cycles in later PRs. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Slack & Travis.

## Screenshots (if appropriate):
![ScreenRecording2019-08-26at11622](https://user-images.githubusercontent.com/15152269/63709139-4dab3100-c804-11e9-9832-e4b84ecb465d.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [X] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
