### PR TITLE
Remove admin requirement for windows. FIXES #181

### DIFF
--- a/slack-dark-mode.ps1
+++ b/slack-dark-mode.ps1
@@ -1,5 +1,3 @@
-#Requires -RunAsAdministrator
-
 Param(
     [string] $CSSUrl = "https://raw.githubusercontent.com/LanikSJ/slack-dark-mode/master/dark-theme.css",
     [string] $SlackBase = $null,


### PR DESCRIPTION
Removing admin requirement for windows since it seems to be causing more trouble than necessary.  May have to revisit once someone comes with another issue saying it wont work for them.


Keep the wiki as is though stating 'require admin mode' since being in admin mode is better than not regardless.

## Related Issue
FIXES https://github.com/LanikSJ/slack-dark-mode/issues/181
https://github.com/LanikSJ/slack-dark-mode/issues/154

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to change)
