### PR TITLE
Fix ssb-interop.bundle.js manipulation

### DIFF
--- a/slack-dark-mode.sh
+++ b/slack-dark-mode.sh
@@ -70,7 +70,8 @@ if [[ "$UPDATE_ONLY" == "false" ]]; then
     sudo npx asar extract $SLACK_RESOURCES_DIR/app.asar $SLACK_RESOURCES_DIR/app.asar.unpacked
 
     # Add JS Code to Slack
-    sudo tee -a "$SLACK_FILEPATH" < $SLACK_EVENT_LISTENER
+    echo "" | sudo tee -a "$SLACK_FILEPATH"
+    cat $SLACK_EVENT_LISTENER | sudo tee -a "$SLACK_FILEPATH"
 
     # Insert the CSS File Location in JS
     sudo sed -i -e s@SLACK_DARK_THEME_PATH@$THEME_FILEPATH@g $SLACK_FILEPATH


### PR DESCRIPTION
Breaks slack v4.0.3 after installation.

## Description
Needed an additional new line before `event-listener.js` could be added to `ssb-interop.bundle.js` otherwise it results in a malformed js file because of a comment on last line (tested against Slac v4.0.3)

## Related Issue
#215 

## Motivation and Context
To fix slack and use with dark theme.

## How Has This Been Tested?
Tested with latest slack v4.0.3 installed via homebrew cask, on macOS Mojave v10.14.6

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
