### PR TITLE
Fix textarea styles for dialog boxes

### DIFF
--- a/dark-theme.css
+++ b/dark-theme.css
@@ -646,6 +646,11 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
   color: var(--main-text);
 }
 
+.c-dialog__body .c-input_character_count .c-input_character_count__characters-remaining {
+  background-color: var(--main-dark-highlight);
+  color: var(--main-dark-highlight);
+}
+
 .c-dialog__body input.c-input_text {
   border-color: var(--main-dark-highlight);
 }
@@ -9220,7 +9225,8 @@ textarea:focus {
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(130, 130, 130, 0.6);
 }
 
-textarea.c-input_textarea.c-input_textarea--with_hint {
+textarea.c-input_textarea.c-input_textarea--with_hint,
+textarea.c-input_textarea.c-input_textarea--with_character_count {
   background-color: var(--main-highlight);
   color: #f8f8f8;
 }

--- a/dark-theme.css
+++ b/dark-theme.css
@@ -648,7 +648,6 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
 
 .c-dialog__body .c-input_character_count .c-input_character_count__characters-remaining {
   background-color: var(--main-dark-highlight);
-  color: var(--main-dark-highlight);
 }
 
 .c-dialog__body input.c-input_text {


### PR DESCRIPTION
Try to fix styles for textarea within dialog box

## Description
Changes the styles applicable for textarea & textarea character count indicator within a dialog box

## Related Issue
Fixes #217 

## Motivation and Context
Since textarea in dialog box are unreadable this is annoying, this attempts to make it better looking and readable. Also same applies for character count indicator.

## How Has This Been Tested?
Manually within skype by updating styles (and using `SLACK_DEVELOPER_MENU="true"`)

## Screenshots (if appropriate):
<img width="523" alt="Screen Shot 2019-09-04 at 1 25 24 AM" src="https://user-images.githubusercontent.com/88258/64228175-008a2780-ceb4-11e9-8055-d18d778e0da5.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
