### PR TITLE
Fix channel browser hover styles

### DIFF
--- a/dark-theme.css
+++ b/dark-theme.css
@@ -4217,6 +4217,10 @@ a.c-member_slug, .c-member_slug--link, .c-mrkdwn__subteam--link {
   background: var(--main-bg-color) !important;
 }
 
+.p-channel_browser_list_item:hover {
+  background: var(--main-dark-highlight) !important;
+}
+
 .p-channel_sidebar__close_container:hover {
   background: #000;
 }


### PR DESCRIPTION
Channel browser hover styles were broken because of being black on black

## Related Issue
Fixes #229 

## How Has This Been Tested?
manually

## Screenshots (if appropriate):
![Screen Shot 2019-09-05 at 11 30 44 AM](https://user-images.githubusercontent.com/88258/64356333-b054b780-cfd0-11e9-947b-03c64a4799b7.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
