### PR TITLE
Temporarily update NPM cache when a space in path exists

### DIFF
--- a/slack-dark-mode.ps1
+++ b/slack-dark-mode.ps1
@@ -6,6 +6,12 @@ Param(
     [switch] $ForceSonicProtection
 )
 
+$default_npm_cache = &npm config get cache --global
+If ($default_npm_cache -match " "){
+    # if the path contains a space, then lets set to a temporary location until we finish.
+    &npm config set cache C:\tmp\nodejs\npm-cache --global
+}
+
 if (-not (Get-Command -Name "npx" -ErrorAction SilentlyContinue)) {
     throw "npx is required to unpack slack. Please install Node for your OS."
 }
@@ -107,4 +113,9 @@ $patch
     } else {
         Set-ItemProperty -Path $localSettingsPath -Name IsReadOnly -Value $false
     }
+}
+
+If ($default_npm_cache -match " "){
+    # if the path contains a space, then lets set it back to the original value.
+    &npm config set cache $default_npm_cache --global
 }

--- a/slack-dark-mode.ps1
+++ b/slack-dark-mode.ps1
@@ -6,14 +6,14 @@ Param(
     [switch] $ForceSonicProtection
 )
 
+if (-not (Get-Command -Name "npx" -ErrorAction SilentlyContinue)) {
+    throw "npx is required to unpack slack. Please install Node for your OS."
+}
+
 $default_npm_cache = &npm config get cache --global
 If ($default_npm_cache -match " "){
     # if the path contains a space, then lets set to a temporary location until we finish.
     &npm config set cache C:\tmp\nodejs\npm-cache --global
-}
-
-if (-not (Get-Command -Name "npx" -ErrorAction SilentlyContinue)) {
-    throw "npx is required to unpack slack. Please install Node for your OS."
 }
 
 $latestPath = $SlackBase


### PR DESCRIPTION
Temporarily updates npm cache to a tmp location while it does our windows updates, and then sets the value back to the original.

## Related Issue
FIXES #238

## Motivation and Context
#238 

## How Has This Been Tested?
tested in a windows VM with a profile with a space in its name

Here is a before and after picture.
![image](https://user-images.githubusercontent.com/479738/64470693-4261da80-d10d-11e9-86da-c310758b63f1.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
