### PR TITLE
Export path with sudo command incase NVM is used.

### DIFF
--- a/slack-dark-mode.sh
+++ b/slack-dark-mode.sh
@@ -67,7 +67,7 @@ if [[ "$UPDATE_ONLY" == "false" ]]; then
     if [[ -f "$HOME/$SLACK_STORE_LOCAL_SETTINGS" ]]; then sudo sed -i 's/"bootSonic":"[^"]*"/"bootSonic":"never"/g' "$HOME/$SLACK_STORE_LOCAL_SETTINGS"; fi
 
     # Unpack Asar Archive for Slack
-    sudo npx asar extract $SLACK_RESOURCES_DIR/app.asar $SLACK_RESOURCES_DIR/app.asar.unpacked
+    sudo "PATH=$PATH" npx asar extract $SLACK_RESOURCES_DIR/app.asar $SLACK_RESOURCES_DIR/app.asar.unpacked
 
     # Add JS Code to Slack
     sudo tee -a "$SLACK_FILEPATH" > /dev/null < $SLACK_EVENT_LISTENER
@@ -76,7 +76,7 @@ if [[ "$UPDATE_ONLY" == "false" ]]; then
     sudo sed -i -e s@SLACK_DARK_THEME_PATH@$THEME_FILEPATH@g $SLACK_FILEPATH
 
     # Pack the Asar Archive for Slack
-    sudo npx asar pack $SLACK_RESOURCES_DIR/app.asar.unpacked $SLACK_RESOURCES_DIR/app.asar
+    sudo "PATH=$PATH" npx asar pack $SLACK_RESOURCES_DIR/app.asar.unpacked $SLACK_RESOURCES_DIR/app.asar
 fi
 
 echo && echo "Done! After executing this script restart Slack for changes to take effect."

--- a/snap-slack-dark-mode.sh
+++ b/snap-slack-dark-mode.sh
@@ -59,7 +59,7 @@ if [[ "$UPDATE_ONLY" == "false" ]]; then
     unmount_slack
 
     # Unpack Asar Archive for Slack
-    sudo npx asar extract $SLACK_RESOURCES_DIR/app.asar $ssb_js_dir/app.asar.unpacked
+    sudo "PATH=$PATH" npx asar extract $SLACK_RESOURCES_DIR/app.asar $ssb_js_dir/app.asar.unpacked
 
     # Add JS Code to Slack
     sudo bash -c "cat $SLACK_EVENT_LISTENER >> $SLACK_FILEPATH"
@@ -68,7 +68,7 @@ if [[ "$UPDATE_ONLY" == "false" ]]; then
     sudo sed -i -e s@SLACK_DARK_THEME_PATH@$THEME_FILEPATH@g $SLACK_FILEPATH
 
     # Pack the Asar Archive for Slack
-    sudo npx asar pack $ssb_js_dir/app.asar.unpacked $ssb_js_dir/app.asar
+    sudo "PATH=$PATH" npx asar pack $ssb_js_dir/app.asar.unpacked $ssb_js_dir/app.asar
 
     sudo mount --bind -o nodev,ro $ssb_js_dir/app.asar $SLACK_RESOURCES_DIR/app.asar
 


### PR DESCRIPTION

## Description
When using NVM, I would get  
```
/usr/bin/env: ‘node’: No such file or directory
/usr/bin/env: ‘node’: No such file or directory
```
Which was causing errors with installing dark-mode.  The issue stemmed from the root user not having access to the local install of node that nvm uses.

To fix this, I simply replace the PATH of the root user with what the local user has for any npx command.

## Related Issue
FIXES: #190

## Motivation and Context
#190

## How Has This Been Tested?
Tested on my local Ubuntu install, with the screenshot below you'll see before and after I applied to fix.

![image](https://user-images.githubusercontent.com/479738/64543302-98d84000-d2ea-11e9-97b4-eb65aef787a1.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
-   [x] My code follows the code style of this project.
-   [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
