### PR TITLE
Fix Unread Messages Notice Styles

### DIFF
--- a/dark-theme.css
+++ b/dark-theme.css
@@ -9732,3 +9732,11 @@ ts-thread ts-message.new_reply:hover {
   color: var(--main-text);
   background-color: #363636F2;
 }
+
+.p-message_pane__unread_banner__close {
+  background: var(--main-dark-highlight);
+}
+
+.p-message_pane__unread_banner__close:hover {
+  background: var(--text-hover);
+}


### PR DESCRIPTION
Unread Messages Notice button 'Mark as read' had styles inconsistent with the dark theme, this change fixes it.

## Related Issue
#250 

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):
![Screen Shot 2019-09-09 at 12 12 28 PM](https://user-images.githubusercontent.com/88258/64548069-ea3cfb00-d2fb-11e9-92c6-c57642437575.png)
on Hover : 
![Screen Shot 2019-09-09 at 12 12 42 PM](https://user-images.githubusercontent.com/88258/64548076-ed37eb80-d2fb-11e9-93fe-8d64af4ba313.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
